### PR TITLE
non material nodes can now have characteristics stored in GUS

### DIFF
--- a/Load/plugin/perl/InsertInvestigations.pm
+++ b/Load/plugin/perl/InsertInvestigations.pm
@@ -504,7 +504,9 @@ sub loadNodes {
       my $gusOntologyTerm = $self->getOntologyTermGusObj($materialTypeOntologyTerm, 0);
       my $ontologyTermId = $gusOntologyTerm->getId();
       $pan->setTypeId($ontologyTermId); # CANNOT Set Parent because OntologyTerm Table has type and subtype.  Both have fk to Sres.ontologyterm
+    }
 
+    if ($node->hasAttribute("Characteristic")) {
       my $characteristics = $node->getCharacteristics();
 
       foreach my $characteristic (@$characteristics) {


### PR DESCRIPTION
Simple fix allows non-material nodes to have Characterisics.

Loaded just one dataset at the moment, but everything is loaded correctly (except attributes of Genotypes and Phenotypes, which is the next issue to tackle).  Confirmatory SQL below and a PDF of the results attached.

`SELECT
    study.protocolappnode.protocol_app_node_id,
    study.protocolappnode.type_id,
    study.protocolappnode.name,
    study.protocolappnode.isa_type,
    study.characteristic.value,
    sres.ontologyterm.name   AS "char_qual_term_name",
    ontologyterm1.name       AS "char_val_term_name",
    ontologyterm2.name       AS "unit_term_name"
FROM
    study.protocolappnode   left
    JOIN study.characteristic ON study.protocolappnode.protocol_app_node_id = study.characteristic.protocol_app_node_id
    LEFT JOIN sres.ontologyterm ON study.characteristic.qualifier_id = sres.ontologyterm.ontology_term_id
    LEFT JOIN sres.ontologyterm       ontologyterm1 ON study.characteristic.ontology_term_id = ontologyterm1.ontology_term_id
    LEFT JOIN sres.ontologyterm       ontologyterm2 ON study.characteristic.unit_id = ontologyterm2.ontology_term_id
WHERE
    study.protocolappnode.row_alg_invocation_id = 6542
ORDER BY
    study.protocolappnode.row_alg_invocation_id DESC`

[loaded-chars.pdf](https://github.com/VEuPathDB/ApiCommonData/files/3973811/loaded-chars.pdf)
