### PR TITLE
Adding the field trials OWL file

### DIFF
--- a/Load/ontology/popbio/field_trials.owl
+++ b/Load/ontology/popbio/field_trials.owl
@@ -1241,6 +1241,19 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     
 
 
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000542 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000542">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000011"/>
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">6</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Name of collection site as given by the data provider. These may not be unique across multiple datasets. For unambiguous place names, use the latitude/longitude-derived place names in continent, country, Aministrative region, level 1&amp;2.</obo:IAO_0000115>
+        <rdfs:label>provider name for collection site</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/FIELD_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000001">
@@ -1500,6 +1513,253 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000028 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000028">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">T0 habitat ID</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000029 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000029">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">habitat permanence</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000030 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000030">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">larval collection method</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000031 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000031">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">season</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000032 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000032">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">weather</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000033 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000033">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">agricultural status</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000034 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000034">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">habitat type</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000035 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000035">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">habitat parameter</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000036 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000036">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">habitat length</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000037 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000037">
+        <rdfs:label xml:lang="en">Units</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000038 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000038">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">habitat width</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000039 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000039">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">number of scoops or swipes</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000040 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000040">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">vegetation type</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000041 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000041">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000004"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">presence of livestock</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000042 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000042">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000005"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">count of larvae</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000043 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000043">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000005"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">macroinvertebrates family</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000044 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000044">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000005"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">common name</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000045 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000045">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000005"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">genera</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000046 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000046">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000006"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">health facility name</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000047 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000047">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000006"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">island</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000048 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000048">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000006"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">distance from Nansio Hospital</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000049 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000049">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000007"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">number of malaria cases</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000050 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000050">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000007"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">total number of malaria tests</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000051 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000051">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000007"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">age group</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000052 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000052">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000010"/>
+        <rdfs:label xml:lang="en">data acquisition</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/OBI_0001620 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001620">
@@ -1534,6 +1794,34 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
         <obo:clinEpi_label>Longitude</obo:clinEpi_label>
         <rdfs:label>Longitude</rdfs:label>
         <rdfs:label xml:lang="en">longitude</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0600018 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0600018">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000010"/>
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>material portioning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UO_0000008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UO_0000008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000037"/>
+        <rdfs:label>meter</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/UO_0010066 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/UO_0010066">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000037"/>
+        <rdfs:label>kilometer</rdfs:label>
     </owl:Class>
     
 
@@ -2060,13 +2348,6 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
         <obo:IAO_0000119>PRISM</obo:IAO_0000119>
         <rdfs:label>obsolete record of unknown death location</rdfs:label>
         <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000542">
-        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">6</obo:EUPATH_0000274>
-        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
-        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
-        <obo:IAO_0000115>Name of collection site as given by the data provider. These may not be unique across multiple datasets. For unambiguous place names, use the latitude/longitude-derived place names in continent, country, Aministrative region, level 1&amp;2.</obo:IAO_0000115>
-        <rdfs:label>provider name for collection site</rdfs:label>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000591">
         <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
@@ -10543,10 +10824,6 @@ This issue is outside the scope of OBI.</obo:IAO_0000116>
 
 Note: this ISA-Tab section also includes terms that used to be in the now-deprecated custom &quot;STUDY TAGS&quot; section. For example, tags/terms like &quot;ICEMR&quot;.</rdfs:comment>
         <rdfs:label>Design and Tag values</rdfs:label>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0600018">
-        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
-        <rdfs:label>material portioning</rdfs:label>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0600047">
         <obo:EUPATH_0001005>value</obo:EUPATH_0001005>

--- a/Load/ontology/popbio/field_trials.owl
+++ b/Load/ontology/popbio/field_trials.owl
@@ -1304,6 +1304,87 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000008 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000008">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000001"/>
+        <rdfs:label xml:lang="en">linker spatial bin</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000009 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000009">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000001"/>
+        <rdfs:label xml:lang="en">linker time period</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000010 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000010">
+        <rdfs:label xml:lang="en">Protocols</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000011 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000011">
+        <rdfs:label xml:lang="en">Shared variables</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000012 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000012">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000010"/>
+        <rdfs:label xml:lang="en">spatio-temporal binning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001620 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001620">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000011"/>
+        <obo:EUPATH_0000274>1</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>lat</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001003>Latitude</obo:EUPATH_0001003>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>degrees</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000185</obo:EUPATH_0001009>
+        <obo:EUPATH_0001013>variableTree</obo:EUPATH_0001013>
+        <obo:clinEpi_label>Latitude</obo:clinEpi_label>
+        <rdfs:label>Latitude</rdfs:label>
+        <rdfs:label xml:lang="en">latitude</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001621 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001621">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000011"/>
+        <obo:EUPATH_0000274>2</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>long</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001003>Longitude</obo:EUPATH_0001003>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>degrees</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000185</obo:EUPATH_0001009>
+        <obo:EUPATH_0001013>variableTree</obo:EUPATH_0001013>
+        <obo:clinEpi_label>Longitude</obo:clinEpi_label>
+        <rdfs:label>Longitude</rdfs:label>
+        <rdfs:label xml:lang="en">longitude</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
     //
@@ -9634,30 +9715,6 @@ Werner suggests a solution based on &quot;Magnitudes&quot; a proposal for which 
         <obo:IAO_0000115>The raw date range(s) as provided or curated by our team. If the dates are &quot;discontinuous&quot; (see other variable) then this variable will show the exact dates.</obo:IAO_0000115>
         <obo:clinEpi_label>Sample collection date</obo:clinEpi_label>
         <rdfs:label>specimen collection date(s) (raw)</rdfs:label>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001620">
-        <obo:EUPATH_0000274>1</obo:EUPATH_0000274>
-        <obo:EUPATH_0000755>lat</obo:EUPATH_0000755>
-        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
-        <obo:EUPATH_0001003>Latitude</obo:EUPATH_0001003>
-        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
-        <obo:EUPATH_0001008>degrees</obo:EUPATH_0001008>
-        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000185</obo:EUPATH_0001009>
-        <obo:EUPATH_0001013>variableTree</obo:EUPATH_0001013>
-        <obo:clinEpi_label>Latitude</obo:clinEpi_label>
-        <rdfs:label>Latitude</rdfs:label>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001621">
-        <obo:EUPATH_0000274>2</obo:EUPATH_0000274>
-        <obo:EUPATH_0000755>long</obo:EUPATH_0000755>
-        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
-        <obo:EUPATH_0001003>Longitude</obo:EUPATH_0001003>
-        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
-        <obo:EUPATH_0001008>degrees</obo:EUPATH_0001008>
-        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000185</obo:EUPATH_0001009>
-        <obo:EUPATH_0001013>variableTree</obo:EUPATH_0001013>
-        <obo:clinEpi_label>Longitude</obo:clinEpi_label>
-        <rdfs:label>Longitude</rdfs:label>
     </rdf:Description>
     <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001622">
         <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</obo:EUPATH_0000274>

--- a/Load/ontology/popbio/field_trials.owl
+++ b/Load/ontology/popbio/field_trials.owl
@@ -12,7 +12,7 @@
      xmlns:terms="http://purl.org/dc/terms/"
      xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
      xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
-    <owl:Ontology rdf:about="http://www.semanticweb.org/maccallr/ontologies/2024/0/untitled-ontology-190"/>
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/field_trials.owl"/>
     
 
 
@@ -1244,7 +1244,62 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     <!-- http://purl.obolibrary.org/obo/FIELD_0000001 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000001">
-        <rdfs:label xml:lang="en">Event linker</rdfs:label>
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">event linker</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000002 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000002">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">adult entomology collection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000003 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000003">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">adult entomology sample</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000004 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000004">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">larval entomology collection</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000005 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000005">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">larval entomology sample</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000006 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000006">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">epidemiology event</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000007 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000007">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">epidemiology result</rdfs:label>
     </owl:Class>
     
 

--- a/Load/ontology/popbio/field_trials.owl
+++ b/Load/ontology/popbio/field_trials.owl
@@ -1,0 +1,12394 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://www.semanticweb.org/maccallr/ontologies/2024/0/untitled-ontology-190/"
+     xml:base="http://www.semanticweb.org/maccallr/ontologies/2024/0/untitled-ontology-190/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:foaf="http://xmlns.com/foaf/0.1/"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:terms="http://purl.org/dc/terms/"
+     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://www.semanticweb.org/maccallr/ontologies/2024/0/untitled-ontology-190"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotation properties
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://protege.stanford.edu/plugins/owl/protege#defaultLanguage -->
+
+    <owl:AnnotationProperty rdf:about="http://protege.stanford.edu/plugins/owl/protege#defaultLanguage"/>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000179 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000179">
+        <obo:IAO_0000115 xml:lang="en">Relates an entity in the ontology to the name of the variable that is used to represent it in the code that generates the BFO OWL file from the lispy specification.</obo:IAO_0000115>
+        <obo:IAO_0000232 xml:lang="en">Really of interest to developers only</obo:IAO_0000232>
+        <rdfs:label xml:lang="en">BFO OWL specification label</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/BFO_0000180 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000180">
+        <obo:IAO_0000115 xml:lang="en">Relates an entity in the ontology to the term that is used to represent it in the the CLIF specification of BFO2</obo:IAO_0000115>
+        <obo:IAO_0000119>Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000232 xml:lang="en">Really of interest to developers only</obo:IAO_0000232>
+        <rdfs:label xml:lang="en">BFO CLIF specification label</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/2000/01/rdf-schema#label"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000052 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000052">
+        <obo:IAO_0000115 xml:lang="en">An alternative label used in VEuPathDB project websites.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">VEuPathDB alternative label</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000274 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000274">
+        <obo:IAO_0000115 xml:lang="en">An annotation property used to specify the order of terms displayed on a website.</obo:IAO_0000115>
+        <obo:IAO_0000118>displayOrder</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">display order</rdfs:label>
+        <rdfs:label>displayOrder</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0000755 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000755">
+        <obo:IAO_0000112>In a data file, there is a column with name &apos;age&apos;. It mapped to EuPath ontology term &apos;age at visit&apos;. We can add &apos;implements variable&apos; annotation with value &apos;age&apos; to term &apos;age at visit&apos;.</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">Column header for each variable from the original datasets (use format from datasets, not data dictionary).</obo:IAO_0000115>
+        <obo:IAO_0000118>column header</obo:IAO_0000118>
+        <rdfs:label>variable</rdfs:label>
+        <rdfs:label xml:lang="en">variable</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001001">
+        <obo:IAO_0000115 xml:lang="en">The original file name for the data file the variable was found in, or a shortened version of the file name that contains all relevant information to identify the data file.</obo:IAO_0000115>
+        <obo:IAO_0000118>dataFile</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">data file</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001002 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001002">
+        <obo:IAO_0000115 xml:lang="en">The highest level parent term (Household, Participant, Observation, Specimen) the variable falls under.</obo:IAO_0000115>
+        <rdfs:label>category</rdfs:label>
+        <rdfs:label xml:lang="en">category</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001003 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001003">
+        <obo:IAO_0000115 xml:lang="en">The variable description from the data dictionary. Useful for assigning display labels. To be provided either directly from the data provider in their codebook or filled out by ClinEpi Outreach before handing over to Ontology.</obo:IAO_0000115>
+        <obo:IAO_0000118>codebookDescription</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">codebook description</rdfs:label>
+        <rdfs:label>codebookDescription</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001004 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001004">
+        <obo:IAO_0000115 xml:lang="en">All possible responses and their mapped terms for each variable, from the data dictionary. Useful for value mapping.</obo:IAO_0000115>
+        <obo:IAO_0000118>codebookValues</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">codebook values</rdfs:label>
+        <rdfs:label>codebookValues</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001005 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001005">
+        <obo:IAO_0000115 xml:lang="en">An annotation that specifies how a term is used in generation search filters on a website. It has five options:
+
+category: a term to organize the variables for exploration on the website
+
+variable: a variable in the dataset
+
+variable, derived: one term that is calculated, using the data in two or more other variables
+
+multifilter: any value below it in the hierarchy will be displayed as a multifilter
+
+value: the value of a multifilter</obo:IAO_0000115>
+        <obo:IAO_0000118>termType</obo:IAO_0000118>
+        <rdfs:label xml:lang="en">term type</rdfs:label>
+        <rdfs:label>termType</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001006 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001006">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that records the ontology term IRI originally used in the study.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>replaces</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label>replaces</rdfs:label>
+        <rdfs:label xml:lang="en">replaces</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001008 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001008">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies units that are associated with a variable (if any) in a human-readable format. Use abbreviations.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>unitLabel</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">unit label</rdfs:label>
+        <rdfs:label>unitLabel</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001009 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001009">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies the ontology term IRI of unit, generally from the unit ontology (UO).</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>unitIRI</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">unit IRI</rdfs:label>
+        <rdfs:label>unitIRI</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001010 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001010">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies which dataset a term belongs to.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>dataSet</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">dataSet</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001011 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001011">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that indicates terms that were assessed longitudinally / repeatedly over time.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>repeated</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label>repeated</rdfs:label>
+        <rdfs:label xml:lang="en">repeated</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001012 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001012">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies important terms to be highlighted.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>is_featured</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">is featured</rdfs:label>
+        <rdfs:label>is_featured</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001013 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001013">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that indicates that the term is hidden from the UI and download files.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>hidden</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label>hidden</rdfs:label>
+        <rdfs:label xml:lang="en">hidden</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001014 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001014">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that identifies terms that are on the log scale or natural log scale, as opposed to on the linear scale.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>scale</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label>scale</rdfs:label>
+        <rdfs:label xml:lang="en">scale</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001015 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001015">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies terms that are related to time, to be used in visualizations looking at data over time. Also to be used in subsetting tab histograms (to indicate that the data range should not include the origin)</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>is_temporal</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">is temporal</rdfs:label>
+        <rdfs:label>is_temporal</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001016 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001016">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies key terms with longitudinal/repeated measures in the studies.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>mergeKey</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">merge key</rdfs:label>
+        <rdfs:label>mergeKey</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001017 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001017">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies default minimum value for each term&apos;s range. Useful to ensure that histograms for related terms have the same x-axis range</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>defaultDisplayRangeMin</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">default display range min</rdfs:label>
+        <rdfs:label>defaultDisplayRangeMin</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001018 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001018">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies the default maximum value for each term&apos;s range. Useful to ensure that histograms for related terms have the same x-axis range</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>defaultDisplayRangeMax</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">default display range max</rdfs:label>
+        <rdfs:label>defaultDisplayRangeMax</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001019 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001019">
+        <obo:IAO_0000115 xml:lang="en">Annotation property that specifies the bin width for each term&apos;s histogram.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>defaultBinWidth</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">default bin width</rdfs:label>
+        <rdfs:label>defaultBinWidth</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/EUPATH_0001020 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/EUPATH_0001020">
+        <obo:IAO_0000115 xml:lang="en">Annotation property used to annotate numeric terms as strings. Numeric terms annotated as strings will ALWAYS be ordinal. Study specific.</obo:IAO_0000115>
+        <obo:IAO_0000117>VEuPathDB team</obo:IAO_0000117>
+        <obo:IAO_0000118>forceStringType</obo:IAO_0000118>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/185</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">force string type</rdfs:label>
+        <rdfs:label>forceStringType</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000111 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000111">
+        <obo:IAO_0000111 xml:lang="en">editor preferred term</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The concise, meaningful, and human-friendly name for a class or property preferred by the ontology developers. (US-English)</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">editor preferred term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000112 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000112">
+        <obo:IAO_0000111 xml:lang="en">example of usage</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A phrase describing how a term should be used and/or a citation to a work which uses it. May also include other kinds of examples that facilitate immediate understanding, such as widely know prototypes or instances of a class, or cases where a relation is said to hold.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">example of usage</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000113 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000113">
+        <obo:IAO_0000111 xml:lang="en">in branch</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">An annotation property indicating which module the terms belong to. This is currently experimental and not implemented yet.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">GROUP:OBI</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">OBI_0000277</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">in branch</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000114 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000114">
+        <obo:IAO_0000111 xml:lang="en">has curation status</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bill Bug</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">has curation status</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000115 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <obo:IAO_0000111 xml:lang="en">definition</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The official definition, explaining the meaning of a class or property. Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">2012-04-05: 
+Barry Smith
+
+The official OBI definition, explaining the meaning of a class or property: &apos;Shall be Aristotelian, formalized and normalized. Can be augmented with colloquial definitions&apos;  is terrible.
+
+Can you fix to something like:
+
+A statement of necessary and sufficient conditions explaining the meaning of an expression referring to a class or property.
+
+Alan Ruttenberg
+
+Your proposed definition is a reasonable candidate, except that it is very common that necessary and sufficient conditions are not given. Mostly they are necessary, occasionally they are necessary and sufficient or just sufficient. Often they use terms that are not themselves defined and so they effectively can&apos;t be evaluated by those criteria. 
+
+On the specifics of the proposed definition:
+
+We don&apos;t have definitions of &apos;meaning&apos; or &apos;expression&apos; or &apos;property&apos;. For &apos;reference&apos; in the intended sense I think we use the term &apos;denotation&apos;. For &apos;expression&apos;, I think we you mean symbol, or identifier. For &apos;meaning&apos; it differs for class and property. For class we want documentation that let&apos;s the intended reader determine whether an entity is instance of the class, or not. For property we want documentation that let&apos;s the intended reader determine, given a pair of potential relata, whether the assertion that the relation holds is true. The &apos;intended reader&apos; part suggests that we also specify who, we expect, would be able to understand the definition, and also generalizes over human and computer reader to include textual and logical definition. 
+
+Personally, I am more comfortable weakening definition to documentation, with instructions as to what is desirable. 
+
+We also have the outstanding issue of how to aim different definitions to different audiences. A clinical audience reading chebi wants a different sort of definition documentation/definition from a chemistry trained audience, and similarly there is a need for a definition that is adequate for an ontologist to work with.  </obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label>definition</rdfs:label>
+        <rdfs:label xml:lang="en">definition</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000116 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000116">
+        <obo:IAO_0000111 xml:lang="en">editor note</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">An administrative note intended for its editor. It may not be included in the publication version of the ontology, so it should contain nothing necessary for end users to understand the ontology.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obofoundry.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">editor note</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000117 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000117">
+        <obo:IAO_0000111 xml:lang="en">term editor</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">Name of editor entering the term in the file. The term editor is a point of contact for information regarding the term. The term editor may be, but is not always, the author of the definition, which may have been worked upon by several people</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">20110707, MC: label update to term editor and definition modified accordingly. See https://github.com/information-artifact-ontology/IAO/issues/115.</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">term editor</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000118 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000118">
+        <obo:IAO_0000111 xml:lang="en">alternative label</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">A label for a class or property that can be used to refer to the class or property instead of the preferred rdfs:label. Alternative labels should be used to indicate community- or context-specific labels, abbreviations, shorthand forms and the like.</obo:IAO_0000115>
+        <obo:IAO_0000117>OBO Operations committee</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:comment>Consider re-defing to: An alternative name for a class or property which can mean the same thing as the preferred name (semantically equivalent, narrow, broad or related).</rdfs:comment>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">alternative label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000119 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000119">
+        <obo:IAO_0000111 xml:lang="en">definition source</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">Formal citation, e.g. identifier in external database to indicate / attribute source(s) for the definition. Free text indicate / attribute source(s) for the definition. EXAMPLE: Author Name, URI, MeSH Term C04, PUBMED ID, Wiki uri on 31.01.2007</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Daniel Schober</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Discussion on obo-discuss mailing-list, see http://bit.ly/hgm99w</obo:IAO_0000119>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">definition source</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000231 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000231">
+        <obo:IAO_0000111 xml:lang="en">has obsolescence reason</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Relates an annotation property to an obsolescence reason. The values of obsolescence reasons come from a list of predefined terms, instances of the class obsolescence reason specification.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">has obsolescence reason</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000232 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000232">
+        <obo:IAO_0000111 xml:lang="en">curator note</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">An administrative note of use for a curator but of no use for a user</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">curator note</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000233 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000233">
+        <obo:IAO_0000111 xml:lang="en">term tracker item</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">the URI for an OBI Terms ticket at sourceforge, such as https://sourceforge.net/p/obi/obi-terms/772/</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">An IRI or similar locator for a request or discussion of an ontology term.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg</obo:IAO_0000119>
+        <rdfs:comment xml:lang="en">The &apos;tracker item&apos; can associate a tracker with a specific ontology term.</rdfs:comment>
+        <rdfs:label xml:lang="en">term tracker item</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000234 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000234">
+        <obo:IAO_0000111 xml:lang="en">ontology term requester</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">The name of the person, project, or organization that motivated inclusion of an ontology term by requesting its addition.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person: Jie Zheng, Chris Stoeckert, Alan Ruttenberg</obo:IAO_0000119>
+        <rdfs:comment>The &apos;term requester&apos; can credit the person, organization or project who request the ontology term.</rdfs:comment>
+        <rdfs:label xml:lang="en">ontology term requester</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000411 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000411">
+        <obo:IAO_0000111 xml:lang="en">is denotator type</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Relates an class defined in an ontology, to the type of it&apos;s denotator</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">In OWL 2 add AnnotationPropertyRange(&apos;is denotator type&apos; &apos;denotator type&apos;)</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">is denotator type</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000412 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000412">
+        <obo:IAO_0000111 xml:lang="en">imported from</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">For external terms/classes, the ontology from which the term was imported</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBI:&lt;http://purl.obolibrary.org/obo/obi&gt;</obo:IAO_0000119>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">imported from</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000424 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000424">
+        <obo:IAO_0000111 xml:lang="en">expand expression to</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">ObjectProperty: RO_0002104
+Label: has plasma membrane part
+Annotations: IAO_0000424 &quot;http://purl.obolibrary.org/obo/BFO_0000051 some (http://purl.org/obo/owl/GO#GO_0005886 and http://purl.obolibrary.org/obo/BFO_0000051 some ?Y)&quot;
+</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">A macro expansion tag applied to an object property (or possibly a data property)  which can be used by a macro-expansion engine to generate more complex expressions from simpler ones</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Chris Mungall</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">expand expression to</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000425 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000425">
+        <obo:IAO_0000111 xml:lang="en">expand assertion to</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">ObjectProperty: RO???
+Label: spatially disjoint from
+Annotations: expand_assertion_to &quot;DisjointClasses: (http://purl.obolibrary.org/obo/BFO_0000051 some ?X)  (http://purl.obolibrary.org/obo/BFO_0000051 some ?Y)&quot;
+</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">A macro expansion tag applied to an annotation property which can be expanded into a more detailed axiom.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Chris Mungall</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">expand assertion to</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000426 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000426">
+        <obo:IAO_0000111 xml:lang="en">first order logic expression</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">first order logic expression</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000427 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000427">
+        <obo:IAO_0000111 xml:lang="en">antisymmetric property</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">part_of antisymmetric property xsd:true</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">Use boolean value xsd:true to indicate that the property is an antisymmetric property</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">antisymmetric property</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/OMO_0001001"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000589 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000589">
+        <obo:IAO_0000111 xml:lang="en">OBO foundry unique label</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">An alternative name for a class or property which is unique across the OBO Foundry.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">The intended usage of that property is as follow: OBO foundry unique labels are automatically generated based on regular expressions provided by each ontology, so that SO could specify unique label = &apos;sequence &apos; + [label], etc. , MA could specify &apos;mouse + [label]&apos; etc. Upon importing terms, ontology developers can choose to use the &apos;OBO foundry unique label&apos; for an imported term or not. The same applies to tools .</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Chris Mungall</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">GROUP:OBO Foundry &lt;http://obofoundry.org/&gt;</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">OBO foundry unique label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000596 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000596">
+        <obo:IAO_0000111 xml:lang="en">has ID digit count</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">Ontology: &lt;http://purl.obolibrary.org/obo/ro/idrange/&gt;
+  Annotations: 
+     &apos;has ID prefix&apos;: &quot;http://purl.obolibrary.org/obo/RO_&quot;
+     &apos;has ID digit count&apos; : 7,
+     rdfs:label &quot;RO id policy&quot;
+     &apos;has ID policy for&apos;: &quot;RO&quot;</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">Relates an ontology used to record id policy to the number of digits in the URI. The URI is: the &apos;has ID prefix&quot; annotation property value concatenated with an integer in the id range (left padded with &quot;0&quot;s to make this many digits)</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">has ID digit count</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000597 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000597">
+        <obo:IAO_0000111 xml:lang="en">has ID range allocated</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">Datatype: idrange:1
+Annotations: &apos;has ID range allocated to&apos;: &quot;Chris Mungall&quot;
+EquivalentTo: xsd:integer[&gt; 2151 , &lt;= 2300]
+</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">Relates a datatype that encodes a range of integers to the name of the person or organization who can use those ids constructed in that range to define new terms</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">has ID range allocated to</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000598 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000598">
+        <obo:IAO_0000111 xml:lang="en">has ID policy for</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">Ontology: &lt;http://purl.obolibrary.org/obo/ro/idrange/&gt;
+  Annotations: 
+     &apos;has ID prefix&apos;: &quot;http://purl.obolibrary.org/obo/RO_&quot;
+     &apos;has ID digit count&apos; : 7,
+     rdfs:label &quot;RO id policy&quot;
+     &apos;has ID policy for&apos;: &quot;RO&quot;</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">Relating an ontology used to record id policy to the ontology namespace whose policy it manages</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">has ID policy for</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000599 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000599">
+        <obo:IAO_0000111 xml:lang="en">has ID prefix</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">Ontology: &lt;http://purl.obolibrary.org/obo/ro/idrange/&gt;
+  Annotations: 
+     &apos;has ID prefix&apos;: &quot;http://purl.obolibrary.org/obo/RO_&quot;
+     &apos;has ID digit count&apos; : 7,
+     rdfs:label &quot;RO id policy&quot;
+     &apos;has ID policy for&apos;: &quot;RO&quot;</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">Relates an ontology used to record id policy to a prefix concatenated with an integer in the id range (left padded with &quot;0&quot;s to make this many digits) to construct an ID for a term being created.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">has ID prefix</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000600 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000600">
+        <obo:IAO_0000111 xml:lang="en">elucidation</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Barry Smith</obo:IAO_0000119>
+        <obo:IAO_0000600 xml:lang="en">Primitive terms in a highest-level ontology such as BFO are terms which are so basic to our understanding of reality that there is no way of defining them in a non-circular fashion. For these, therefore, we can provide only elucidations, supplemented by examples and by axioms</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">elucidation</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000601 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000601">
+        <obo:IAO_0000111 xml:lang="en">has associated axiom(nl)</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000600 xml:lang="en">An axiom associated with a term expressed using natural language</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has associated axiom(nl)</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000602 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000602">
+        <obo:IAO_0000111 xml:lang="en">has associated axiom(fol)</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000600 xml:lang="en">An axiom expressed in first order logic using CLIF syntax</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has associated axiom(fol)</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000603 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000603">
+        <obo:IAO_0000111 xml:lang="en">is allocated id range</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Relates an ontology IRI to an (inclusive) range of IRIs in an OBO name space. The range is give as, e.g. &quot;IAO_0020000-IAO_0020999&quot;</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:comment xml:lang="en">Add as annotation triples in the granting ontology</rdfs:comment>
+        <rdfs:label xml:lang="en">is allocated id range</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0000700 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000700">
+        <obo:IAO_0000111 xml:lang="en">has ontology root term</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Ontology annotation property. Relates an ontology to a term that is a designated root term of the ontology. Display tools like OLS can use terms annotated with this property as the starting point for rendering the ontology class hierarchy. There can be more than one root.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Nicolas Matentzoglu</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">has ontology root term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0006011 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0006011">
+        <obo:IAO_0000111 xml:lang="en">may be identical to</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A annotation relationship between two terms in an ontology that may refer to the same (natural) type but where more evidence is required before terms are merged.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">David Osumi-Sutherland</obo:IAO_0000117>
+        <obo:IAO_0000233 xml:lang="en">#40</obo:IAO_0000233>
+        <obo:IAO_0000234 xml:lang="en">VFB</obo:IAO_0000234>
+        <rdfs:comment xml:lang="en">Edges asserting this should be annotated with to record evidence supporting the assertion and its provenance.</rdfs:comment>
+        <rdfs:label xml:lang="en">may be identical to</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0006012 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0006012">
+        <obo:IAO_0000111 xml:lang="en">scheduled for obsoletion on or after</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Used when the class or object is scheduled for obsoletion/deprecation on or after a particular date.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Chris Mungall, Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000233 xml:lang="en">https://github.com/geneontology/go-ontology/issues/15532</obo:IAO_0000233>
+        <obo:IAO_0000233 xml:lang="en">https://github.com/information-artifact-ontology/ontology-metadata/issues/32</obo:IAO_0000233>
+        <obo:IAO_0000234 xml:lang="en">GO ontology</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">scheduled for obsoletion on or after</rdfs:label>
+        <rdfs:range rdf:resource="http://www.w3.org/2001/XMLSchema#dateTime"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0010000 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0010000">
+        <obo:IAO_0000111 xml:lang="en">has axiom id</obo:IAO_0000111>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000600 xml:lang="en">A URI that is intended to be unique label for an axiom used for tracking change to the ontology. For an axiom expressed in different languages, each expression is given the same URI</obo:IAO_0000600>
+        <rdfs:isDefinedBy rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has axiom label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/IAO_0100001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0100001">
+        <obo:IAO_0000111 xml:lang="en">term replaced by</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">Use on obsolete terms, relating the term to another term that can be used as a substitute</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000119>
+        <rdfs:comment xml:lang="en">Add as annotation triples in the granting ontology</rdfs:comment>
+        <rdfs:label xml:lang="en">term replaced by</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001847 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001847">
+        <obo:IAO_0000111 xml:lang="en">ISA alternative term</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115>An alternative term used by the ISA tools project (http://isa-tools.org).</obo:IAO_0000115>
+        <obo:IAO_0000116>Requested by Alejandra Gonzalez-Beltran
+https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891&amp;atid=886178</obo:IAO_0000116>
+        <obo:IAO_0000117>Person: Alejandra Gonzalez-Beltran</obo:IAO_0000117>
+        <obo:IAO_0000117>Person: Philippe Rocca-Serra</obo:IAO_0000117>
+        <obo:IAO_0000119>ISA tools project (http://isa-tools.org)</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">ISA alternative term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_0001886 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_0001886">
+        <obo:IAO_0000111 xml:lang="en">NIAID GSCID-BRC alternative term</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115>An alternative term used by the National Institute of Allergy and Infectious Diseases (NIAID) Genomic Sequencing Centers for Infectious Diseases (GSCID) and Bioinformatics Resource Centers (BRC).</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON: Chris Stoeckert, Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">NIAID GSCID-BRC alternative term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OBI_9991118 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OBI_9991118">
+        <obo:IAO_0000111>IEDB alternative term</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115>An alternative term used by the IEDB.</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON:Randi Vita, Jason Greenbaum, Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000119>IEDB</obo:IAO_0000119>
+        <rdfs:label>IEDB alternative term</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0001001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0001001">
+        <obo:IAO_0000115>This is an annotation used on an object property to indicate a logical characterstic beyond what is possible in OWL.</obo:IAO_0000115>
+        <obo:IAO_0000119>OBO Operations call</obo:IAO_0000119>
+        <oboInOwl:created_by rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
+        <rdfs:label>logical characteristic of object property</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0002000 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0002000">
+        <obo:IAO_0000112>&apos;part disjoint with&apos; &apos;defined by construct&apos; &quot;&quot;&quot;
+    PREFIX owl: &lt;http://www.w3.org/2002/07/owl#&gt;
+    PREFIX : &lt;http://example.org/
+    CONSTRUCT {
+      [
+        a owl:Restriction ;
+        owl:onProperty :part_of ;
+        owl:someValuesFrom ?a ;
+        owl:disjointWith [
+          a owl:Restriction ;
+          owl:onProperty :part_of ;
+          owl:someValuesFrom ?b
+        ]
+      ]
+    }
+    WHERE {
+      ?a :part_disjoint_with ?b .
+    }</obo:IAO_0000112>
+        <obo:IAO_0000115>Links an annotation property to a SPARQL CONSTRUCT query which is meant to provide semantics for a shortcut relation.</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/ontodev/robot/issues/963"/>
+        <dc:contributor rdf:resource="https://orcid.org/0000-0002-7356-1779"/>
+        <dc:contributor rdf:resource="https://orcid.org/0000-0002-8688-6599"/>
+        <rdfs:label>defined by construct</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0003000 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0003000">
+        <obo:IAO_0000112>CHEBI:26523 (reactive oxygen species) has an exact synonym (ROS), which is of type OMO:0003000 (abbreviation)</obo:IAO_0000112>
+        <obo:IAO_0000115>A synonym type for describing abbreviations or initalisms</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/ontology-metadata/issues/122"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-03-03</terms:created>
+        <rdfs:label>abbreviation</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SynonymType"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0003001 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0003001">
+        <obo:IAO_0000115>A synonym type for describing ambiguous synonyms</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/ontology-metadata/issues/122"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-03-03</terms:created>
+        <rdfs:label>ambiguous synonym</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SynonymType"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0003002 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0003002">
+        <obo:IAO_0000115>A synonym type for describing dubious synonyms</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/ontology-metadata/issues/122"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-03-03</terms:created>
+        <rdfs:label>dubious synonym</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SynonymType"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0003003 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0003003">
+        <obo:IAO_0000112>EFO:0006346 (severe cutaneous adverse reaction) has an exact synonym (scar), which is of the type OMO:0003003 (layperson synonym)</obo:IAO_0000112>
+        <obo:IAO_0000115>A synonym type for describing layperson or colloquial synonyms</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/ontology-metadata/issues/122"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-03-03</terms:created>
+        <rdfs:label>layperson synonym</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SynonymType"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0003004 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0003004">
+        <obo:IAO_0000112>CHEBI:23367 (molecular entity) has an exact synonym (molecular entities), which is of the type OMO:0003004 (plural form)</obo:IAO_0000112>
+        <obo:IAO_0000115>A synonym type for describing pluralization synonyms</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/ontology-metadata/issues/122"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-03-03</terms:created>
+        <rdfs:label>plural form</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SynonymType"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/OMO_0003005 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/OMO_0003005">
+        <obo:IAO_0000112>CHEBI:16189 (sulfate) has an exact synonym (sulphate), which is of the type OMO:0003005 (UK spelling synonym)</obo:IAO_0000112>
+        <obo:IAO_0000115>A synonym type for describing UK spelling variants</obo:IAO_0000115>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/ontology-metadata/issues/122"/>
+        <terms:contributor rdf:resource="https://orcid.org/0000-0003-4423-4370"/>
+        <terms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-03-03</terms:created>
+        <rdfs:label>UK spelling synonym</rdfs:label>
+        <rdfs:subPropertyOf rdf:resource="http://www.geneontology.org/formats/oboInOwl#SynonymType"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/POPBIO_8000181 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000181">
+        <rdfs:comment>Currently this is used to point a categorical variable to a count variable for use with surveillance sample data where zero count records are not stored in the database. Values should be of the form &quot;entityId.variableId&quot; (no quotes)</rdfs:comment>
+        <rdfs:label xml:lang="en">variableSpecToImputeZeroesFor</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/POPBIO_8000183 -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000183">
+        <rdfs:label xml:lang="en">hasStudyDependentVocabulary</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/clinEpi_label -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/clinEpi_label">
+        <rdfs:label>clinEpi_label</rdfs:label>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/contributor -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/contributor"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/coverage -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/coverage"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/creator -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/creator"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/date -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/date"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/description -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/description"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/format -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/format"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/identifier -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/identifier"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/language -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/language"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/member -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/member"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/publisher -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/publisher"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/relation -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/relation"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/rights -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/rights"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/source -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/source"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/subject -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/subject"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/title -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/title"/>
+    
+
+
+    <!-- http://purl.org/dc/elements/1.1/type -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/elements/1.1/type"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/contributor -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/contributor"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/created -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/created"/>
+    
+
+
+    <!-- http://purl.org/dc/terms/license -->
+
+    <owl:AnnotationProperty rdf:about="http://purl.org/dc/terms/license"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#SynonymType -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#SynonymType"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#created_by -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#created_by"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#creation_date -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#creation_date"/>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym">
+        <obo:IAO_0000115>An alternative label for a class or property which has a more general meaning than the preferred name/primary label.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
+        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/18</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">has broad synonym</rdfs:label>
+        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/18</rdfs:seeAlso>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasExactSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasExactSynonym">
+        <obo:IAO_0000115>An alternative label for a class or property which has the exact same meaning than the preferred name/primary label.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
+        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/20</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">has exact synonym</rdfs:label>
+        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/20</rdfs:seeAlso>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym">
+        <obo:IAO_0000115>An alternative label for a class or property which has a more specific meaning than the preferred name/primary label.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
+        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/19</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">has narrow synonym</rdfs:label>
+        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/19</rdfs:seeAlso>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym -->
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym">
+        <obo:IAO_0000115>An alternative label for a class or property that has been used synonymously with the primary term name, but the usage is not strictly correct.</obo:IAO_0000115>
+        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
+        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/21</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">has related synonym</rdfs:label>
+        <rdfs:seeAlso>https://github.com/information-artifact-ontology/ontology-metadata/issues/21</rdfs:seeAlso>
+        <rdfs:subPropertyOf rdf:resource="http://purl.obolibrary.org/obo/IAO_0000118"/>
+    </owl:AnnotationProperty>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#isDefinedBy -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#isDefinedBy"/>
+    
+
+
+    <!-- http://www.w3.org/2000/01/rdf-schema#seeAlso -->
+
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/2000/01/rdf-schema#seeAlso"/>
+    
+
+
+    <!-- http://xmlns.com/foaf/0.1/homepage -->
+
+    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/homepage"/>
+    
+
+
+    <!-- http://xmlns.com/foaf/0.1/mbox -->
+
+    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/mbox"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Datatypes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://www.w3.org/2001/XMLSchema#date -->
+
+    <rdfs:Datatype rdf:about="http://www.w3.org/2001/XMLSchema#date"/>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Classes
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000001 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000001">
+        <rdfs:label xml:lang="en">Event linker</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- 
+    ///////////////////////////////////////////////////////////////////////////////////////
+    //
+    // Annotations
+    //
+    ///////////////////////////////////////////////////////////////////////////////////////
+     -->
+
+    <rdf:Description rdf:about="http://purl.bioontology.org/ontology/SNMI/L-26206">
+        <rdfs:label>Vibrio cholerae serotype Inaba</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.bioontology.org/ontology/SNMI/L-26207">
+        <rdfs:label>Vibrio cholerae serotype Ogawa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.bioontology.org/ontology/SNOMEDCT/125014008">
+        <rdfs:label>Shigella flexneri, serovar 3c</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.bioontology.org/ontology/SNOMEDCT/125017001">
+        <rdfs:label>Shigella flexneri, serovar 4b</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.bioontology.org/ontology/SNOMEDCT/22097005">
+        <obo:IAO_0000118>Tree (organism)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.bioontology.org/ontology/SNOMEDCT"/>
+        <rdfs:label xml:lang="en">Tree</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.bioontology.org/ontology/SNOMEDCT/224619008">
+        <rdfs:label>Migrant</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/APOLLO_SV_00000445">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>mortality rate</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000050">
+        <obo:IAO_0000115 xml:lang="en">a core relation that holds between a part and its whole</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">part_of</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">part of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000051">
+        <obo:IAO_0000115 xml:lang="en">a core relation that holds between a whole and its part</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">has_part</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has part</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000054">
+        <obo:IAO_0000118 xml:lang="en">is realized by</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">realized_in</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">realized in</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000055">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">realizes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000063">
+        <obo:IAO_0000115 xml:lang="en">x precedes y if and only if the time point at which x ends is before or equivalent to the time point at which y starts. Formally: x precedes y iff ω(x) &lt;= α(y), where α is a function that maps a process to a start point, and ω is a function that maps a process to an end point.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">precedes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000066">
+        <obo:IAO_0000115 xml:lang="en">b occurs_in c =def b is a process and c is a material entity or immaterial entity&amp; there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.&amp; forall(t) if b exists_at t then c exists_at t &amp; there exist spatial regions s and s’ where &amp; b spatially_projects_onto s at t&amp; c is occupies_spatial_region s’ at t&amp; s is a proper_continuant_part_of s’ at t</obo:IAO_0000115>
+        <obo:IAO_0000118 xml:lang="en">occurs_in</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">unfolds in</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">unfolds_in</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">occurs in</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/BFO_0000067">
+        <obo:IAO_0000115 xml:lang="en">[copied from inverse property &apos;occurs in&apos;] b occurs_in c =def b is a process and c is a material entity or immaterial entity&amp; there exists a spatiotemporal region r and b occupies_spatiotemporal_region r.&amp; forall(t) if b exists_at t then c exists_at t &amp; there exist spatial regions s and s’ where &amp; b spatially_projects_onto s at t&amp; c is occupies_spatial_region s’ at t&amp; s is a proper_continuant_part_of s’ at t</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">contains process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_16130">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>DDT</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_16526">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>carbon dioxide</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_167184">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>chlorthion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_24852">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>group1.insecticide</rdfs:label>
+        <rdfs:label>insecticide</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_26413">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>pyrethroid</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_3093">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>bifenthrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_32888">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>lindane</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_3390">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>carbaryl</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34118">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">octenol</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34556">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>bendiocarb</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34631">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>chlorpyrifos</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34632">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>chlorpyrifos-methyl</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34690">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>dichlorvos</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34696">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>dieldrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34703">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>diflubenzuron</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34714">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>dimethoate</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34757">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>fenitrothion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34761">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>fenthion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34839">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">methoprene</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34911">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>permethrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34916">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">phenothrin [(1R)-trans- isomer]</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34917">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>phenthoate</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_34938">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>propoxur</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_38476">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>carbosulfan</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_38677">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>famphur</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_38680">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>fenamiphos</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_38843">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>pirimiphos-methyl</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_38845">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>profenofos</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_38954">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>temephos</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39178">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>clothianidin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39211">
+        <rdfs:label xml:lang="en">spinosad</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39260">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">pyriproxyfen</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39314">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>beta-cyfluthrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39325">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>lambda-cyhalothrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39331">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>alpha-cypermethrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39332">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>beta-cypermethrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39347">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>chlorfenapyr</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39348">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>etofenprox</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39397">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">tetramethrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_39402">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>ZXI 8901</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_4034">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>cyfluthrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_4035">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>cyhalothrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_4042">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>cypermethrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_4388">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>deltamethrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_5063">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">fipronil</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_5870">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>imidacloprid</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_6649">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>malaoxon</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_6651">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>malathion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_6842">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>methoxychlor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_6908">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">trichlorfon</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_82108">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>chlorphoxim</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CHEBI_8811">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">resmethrin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/CL_0000010">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>cultured cell</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000016">
+        <rdfs:label>executed by</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/COB_0000086">
+        <rdfs:label>executes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EFO_0004667">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>biological variation design</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_00000005">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">3</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:comment>This variable will be auto-populated at load time by looking up GADM polygons.</rdfs:comment>
+        <rdfs:label>Administrative region, level 1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_00000006">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">4</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:comment>This variable will be auto-populated at load time by looking up GADM polygons.</rdfs:comment>
+        <rdfs:label>Administrative region, level 2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/ENVO_01001117">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">chicken manure</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000005">
+        <obo:IAO_0000115>A relation between a medication material and a disease or symptom that it may treat.</obo:IAO_0000115>
+        <obo:IAO_0000116>no longer in use</obo:IAO_0000116>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+        <rdfs:label>obsolete material may be used for</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000044">
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+        <rdfs:label>obsolete manifestation of</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000060">
+        <obo:IAO_0000115>A relation between a medication material and a disease or symptom that it may treat.</obo:IAO_0000115>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000103"/>
+        <obo:IAO_0000233 rdf:resource="https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/121"/>
+        <rdfs:label>obsolete may treat</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000061">
+        <obo:IAO_0000115>A relation between a drug product and (one of) its active ingredient.</obo:IAO_0000115>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000228"/>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/RO_0002248"/>
+        <rdfs:label>obsolete has active ingredient</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000104">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Organism under investigation TEMP WIP</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000223">
+        <obo:IAO_0000115>A categorical household wealth index representing the bottom third of values for the numerical household wealth index.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete bottom household wealth index</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000224">
+        <obo:IAO_0000115>A categorical household wealth index representing the middle third of values for the numerical household wealth index.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete middle household wealth index</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000225">
+        <obo:IAO_0000115>A categorical household wealth index representing the top third of values for the numerical household wealth index.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete top household wealth index</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000226">
+        <obo:IAO_0000115>A information content entity created to indicate the lack of air bricks in the dwelling.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete no airbrick</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000227">
+        <obo:IAO_0000115>A information content entity indicating that the household eats in restaurants.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete record of eating in restaurants</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000228">
+        <obo:IAO_0000115>A information content entity indicating that the household does not cook in the dwelling.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete record of no cooking at home</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000229">
+        <obo:IAO_0000115>An information content entity indicates no toilet facility in the dwelling.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete record of no toilet facility</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000230">
+        <obo:IAO_0000115>An information content entity indicating that a household uses a neighbours&apos; toilet facility.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete record of using neighbours&apos; toilet</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000231">
+        <obo:IAO_0000115>A time of screening occurring during the initial human subject enrollment period.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete time of screening during initial enrollment</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000232">
+        <obo:IAO_0000115>A time of screening occuring after the initial enrollment period had ended and the study had begun.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person:  Jie Zheng, Chris Stoeckert, David Roos, Grant Dorsey</obo:IAO_0000117>
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <obo:IAO_0000119>Penn Group</obo:IAO_0000119>
+        <rdfs:label>obsolete time of screenng after initial enrollment</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000233">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete unknown withdrawal reason</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000234">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete withdrew due to death</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000235">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete inability to comply with protocol</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000236">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete moved out of area</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000237">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete reached 11 years of age</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000238">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete unable to be located for over 120 days</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000239">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete withdrawal of all children under care</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000240">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete withdrawal of informed consent</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000241">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete unknown cause of death</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000242">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete complications of HIV</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000243">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete diarrheal illness</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000244">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete suicide</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000245">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete Bwindi Hospital</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000246">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete Jinja Hospital</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000247">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete Kauka Health Centre</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000248">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete Kihihi Health Centre IV</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000249">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete Nagongera Health Centre IV</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000250">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete Tororo District Hospital</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000251">
+        <obo:IAO_0000119>PRISM</obo:IAO_0000119>
+        <rdfs:label>obsolete record of unknown death location</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000542">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">6</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Name of collection site as given by the data provider. These may not be unique across multiple datasets. For unambiguous place names, use the latitude/longitude-derived place names in continent, country, Aministrative region, level 1&amp;2.</obo:IAO_0000115>
+        <rdfs:label>provider name for collection site</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000591">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>host organism</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000605">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Study</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000609">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:clinEpi_label>Sample</obo:clinEpi_label>
+        <rdfs:label>Sample</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000611">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Sample type</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000756">
+        <obo:EUPATH_0001002>Pathogen detection assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>pathogen organism</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000792">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>minute</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000031</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide time 50</obo:IAO_0000115>
+        <rdfs:label>LT50</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0000808">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0009998">
+        <obo:IAO_0000112>the growth of a child during three years after birth</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">A unit that represents a change in length of one centimeter in one year.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000118>cm/year</obo:IAO_0000118>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/522</obo:IAO_0000233>
+        <obo:IAO_0000234>ClinEpiDB</obo:IAO_0000234>
+        <dc:contributor>Danica Helb</dc:contributor>
+        <dc:contributor>Jie Zheng</dc:contributor>
+        <rdfs:label xml:lang="en">centimeter per year</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0009999">
+        <obo:IAO_0000112>the increase in mass of a child during three years after birth</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">A unit that represents a change in mass of one kilogram in one year.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000118>kg/year</obo:IAO_0000118>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/523</obo:IAO_0000233>
+        <obo:IAO_0000234>ClinEpiDB</obo:IAO_0000234>
+        <dc:contributor>Danica Helb</dc:contributor>
+        <dc:contributor>Jie Zheng</dc:contributor>
+        <rdfs:label xml:lang="en">kilogram per year</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0010889">
+        <obo:EUPATH_0001002>Pathogen detection assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:clinEpi_label>Any pathogen, by any method</obo:clinEpi_label>
+        <rdfs:label>presence of pathogen</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043001">
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Attractant</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043002">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>alfalfa infusion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043003">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>BG-lure scent dispenser</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043004">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>hay infusion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043005">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>information specifying no arthropod attractor used</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043027">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>larval specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043046">
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>count of traps</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043048">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>hand-held sweep net</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043050">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Centers for Disease Control and Prevention gravid trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043054">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>free-standing window trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043055">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">trap or shelter for resting adult arthropods</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043060">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>pupal specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043063">
+        <obo:IAO_0000116>An organization that manufactures mosquito traps and other mosquito control products.</obo:IAO_0000116>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000228"/>
+        <obo:IAO_0100001 rdf:resource="http://purl.obolibrary.org/obo/OBI_0002903"/>
+        <rdfs:label>obsolete BioGents</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043064">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>duration time of insecticide exposure</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043065">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">UV light source</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043067">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Psorophora johnstonii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043068">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Psorophora mathesoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043069">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Psorophora mexicana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043070">
+        <obo:IAO_0000116>This subspecies is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Toxorhynchites rutilus rutilus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043071">
+        <obo:IAO_0000116>This taxonomic label is not in NCBITaxon, so this term is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes atlanticus-tormentor morphological group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043072">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes fijiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043073">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes hodgkini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043074">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes hokkaidensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043075">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes idahoensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043078">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes mathesoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043079">
+        <obo:IAO_0000116>This taxonomic label is not in NCBITaxon, so this term is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000119>VBsp:0000997</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes mathesoni complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043080">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes subdentatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043081">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes tricholabis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043082">
+        <obo:IAO_0000116>This subspecies is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes vexans arabiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043083">
+        <obo:IAO_0000116>This taxonomic label is not in NCBITaxon, so this term is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes vexans sensu lato</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043084">
+        <obo:IAO_0000116>This subspecies is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes vexans vexans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043085">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Aedes washinoi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043087">
+        <obo:IAO_0000116>This taxonomic label is not in NCBITaxon, so this term is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117> Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902 </obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles culicifacies AD subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043088">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles distinctus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043089">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles flavicosta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043091">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles georgianus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043092">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles listeri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043093">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles natalensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043094">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles perplexens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043095">
+        <obo:IAO_0000116>This taxonomic label is not in NCBITaxon, so this term is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles sinensis sensu lato</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043096">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Anopheles umbrosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043098">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Culex chorleyi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043099">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Culex cinerellus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043100">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Culex cuyanus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043102">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Culex lineata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043103">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Culex peringueyi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043105">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Culex salisburiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043107">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Culex trifoliatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043111">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Sergentomyia theodori</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043112">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Uranotaenia hopkinsi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043114">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/105</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <rdfs:label xml:lang="en">Wyeomyia haynei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043117">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>insecticide concentration in percent</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043118">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>parts per million</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000169</obo:EUPATH_0001009>
+        <rdfs:label>insecticide concentration in parts per notation unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043119">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>milligram per square meter</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000309</obo:EUPATH_0001009>
+        <rdfs:label>insecticide concentration in area density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043120">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>insecticide concentration in mass density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043121">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>insecticide concentration in mass per standard assay bottle</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043123">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 50 in percent</obo:IAO_0000115>
+        <rdfs:label>LC50 measured in percent</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043124">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>lethal insecticide concentration 50 in parts per notation unit</obo:IAO_0000115>
+        <rdfs:label>LC50 measured in parts per notation unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043125">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>gram per square meter</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0010049</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 50 in area density unit</obo:IAO_0000115>
+        <rdfs:label>LC50 measured in area density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043126">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>lethal insecticide concentration 50 in mass density unit</obo:IAO_0000115>
+        <rdfs:label>LC50 measured in mass density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043127">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>micrograms per wheaton bottle</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0010053</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 50 in mass per standard assay bottle</obo:IAO_0000115>
+        <rdfs:label>LC50 measured in mass per standard assay bottle</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043130">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>lethal insecticide concentration 95 in parts per notation unit</obo:IAO_0000115>
+        <rdfs:label>LC95 measured in parts per notation unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043131">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>gram per square meter</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0010049</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 95 in area density unit</obo:IAO_0000115>
+        <rdfs:label>LC95 measured in area density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043132">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>lethal insecticide concentration 95 in mass density unit</obo:IAO_0000115>
+        <rdfs:label>LC95 measured in mass density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043133">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>lethal insecticide concentration 95 in mass per standard assay bottle</obo:IAO_0000115>
+        <rdfs:label>LC95 measured in mass per standard assay bottle</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043136">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>parts per million</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000169</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 99 in parts per notation unit</obo:IAO_0000115>
+        <rdfs:label>LC99 measured in parts per notation unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043138">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>milligram per liter</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000273</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 99 in mass density unit</obo:IAO_0000115>
+        <rdfs:label>LC99 measured in mass density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043139">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>lethal insecticide concentration 99 in mass per standard assay bottle</obo:IAO_0000115>
+        <rdfs:label>LC99 measured in mass per standard assay bottle</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043140">
+        <obo:IAO_0000115 xml:lang="en">A ratio unit that denotes the mean enzymatic activity of a field-collected population of specimens compared to that of a reference population, normalized by a base two logarithmic transformation.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001116</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">unit of log2 ratio of specimen population mean enzymatic activity to that of reference specimen population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043141">
+        <obo:IAO_0000115 xml:lang="en">A ratio unit that denotes the median enzymatic activity of a field-collected population of specimens compared to that of a reference population, normalized by a base two logarithmic transformation.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001124</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">unit of log2 ratio of specimen population median enzymatic activity to that of reference specimen population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043142">
+        <obo:IAO_0000115 xml:lang="en">A fraction unit that denotes the fraction of a population exhibiting higher enzymatic activity than the 99th percentile of a reference population.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001111</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">unit of population fraction with greater enzymatic activity than 99th percentile of reference population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043145">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>minute</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000031</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide time 90</obo:IAO_0000115>
+        <rdfs:label>LT90</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043146">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>minute</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000031</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide time 95</obo:IAO_0000115>
+        <rdfs:label>LT95</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043147">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>minute</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000031</obo:EUPATH_0001009>
+        <rdfs:label>median knockdown time</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043148">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>parts per million</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000169</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 90 in parts per notation unit</obo:IAO_0000115>
+        <rdfs:label>LC90 measured in parts per notation unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043150">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>milligram per liter</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000273</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 90 in mass density unit</obo:IAO_0000115>
+        <rdfs:label>LC90 measured in mass density unit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043152">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>new mean ratio term</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/EUPATH_0043140</obo:EUPATH_0001009>
+        <obo:IAO_0000115>ratio of specimen population mean enzymatic activity to that of reference specimen population</obo:IAO_0000115>
+        <rdfs:label>enzyme activity ratio (mean population reference)</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043153">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>new median ratio term</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/EUPATH_0043141</obo:EUPATH_0001009>
+        <obo:IAO_0000115>ratio of specimen population median enzymatic activity to that of reference specimen population</obo:IAO_0000115>
+        <rdfs:label>enzyme activity ratio (median population reference)</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043154">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>population fraction with greater enzymatic activity than 99th percentile of reference population</obo:IAO_0000115>
+        <rdfs:label>fraction with greater enzymatic activity than 99th percentile of reference</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043155">
+        <obo:EUPATH_0001002>Blood meal assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Pathogen detection assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Phenotype assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>specimen count</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043156">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr L1014F</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043157">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr S989P</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043158">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr I1011M</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043159">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr I1011V</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043160">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr L1014S</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043161">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr L1014C</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043162">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr V1016G</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043163">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr V1016I</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043164">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr I1532T</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043165">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr F1534C</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043166">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr F1534L</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043167">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr F1534S</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043168">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr N1575Y</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043169">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Kdr D1763Y</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043170">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of AChE1 G119S</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043174">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Gste2 L119F</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043175">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Rdl A296G</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043176">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of Rdl A296S</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043178">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr L1014</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043179">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr S989</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043180">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr I1011</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043181">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr V1016</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043182">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr I1532</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043183">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr F1534</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043184">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr N1575</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043185">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Kdr D1763</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043186">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type AChE1 G119</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043190">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Gste2 L119</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043191">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of wild type Rdl A296P</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043192">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>egg specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043193">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">collection of larvae from traps</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043194">
+        <obo:EUPATH_0001002>Organism identification assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>organism identification datum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043196">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <obo:IAO_0000115>lethal insecticide concentration 100 in percent</obo:IAO_0000115>
+        <rdfs:label>LC100 measured in percent</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043201">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>BG-Lure</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043203">
+        <obo:EUPATH_0000274>3</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>geohash1</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable, derived</obo:EUPATH_0001005>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:label>GEOHASH 1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043204">
+        <obo:EUPATH_0000274>4</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>geohash2</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable, derived</obo:EUPATH_0001005>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:label>GEOHASH 2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043205">
+        <obo:EUPATH_0000274>5</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>geohash3</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable, derived</obo:EUPATH_0001005>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:label>GEOHASH 3</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043206">
+        <obo:EUPATH_0000274>6</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>geohash4</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable, derived</obo:EUPATH_0001005>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:label>GEOHASH 4</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043207">
+        <obo:EUPATH_0000274>7</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>geohash5</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable, derived</obo:EUPATH_0001005>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:label>GEOHASH 5</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043208">
+        <obo:EUPATH_0000274>8</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>geohash6</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable, derived</obo:EUPATH_0001005>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:label>GEOHASH 6</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043211">
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Geolocation provenance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043212">
+        <obo:EUPATH_0000274>1</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Community</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Geolocation precision</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043213">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>A geolocation precision objective specification of zero decimal places.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/126</obo:IAO_0000233>
+        <rdfs:label>geolocation precision objective of zero decimal places</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043214">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>A geolocation precision objective specification of one decimal place.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/126</obo:IAO_0000233>
+        <rdfs:label>geolocation precision objective of one decimal place</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043215">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>A geolocation precision objective specification of two decimal places.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/126</obo:IAO_0000233>
+        <rdfs:label>geolocation precision objective of two decimal places</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043216">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>A geolocation precision objective specification of three decimal places.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/126</obo:IAO_0000233>
+        <rdfs:label>geolocation precision objective of three decimal places</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043217">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>A geolocation precision objective specification of four decimal places.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/126</obo:IAO_0000233>
+        <rdfs:label>geolocation precision objective of four decimal places</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043218">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Actellic 300CS</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043219">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>count of 2La inversion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043220">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>count of 2Rb inversion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043221">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>count of 2Rc inversion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043222">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>count of 2Rd inversion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043223">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>count of 2Rj inversion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043224">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>count of 2Rk inversion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043225">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>count of 2Ru inversion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043227">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:POPBIO_8000181>EUPATH_0000609.POPBIO_8000017</obo:POPBIO_8000181>
+        <obo:POPBIO_8000183>yes</obo:POPBIO_8000183>
+        <rdfs:label>female insect feeding status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043231">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>unfed female insect status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043232">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>fed female insect status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043233">
+        <obo:IAO_0000115 xml:lang="en">An organization that monitors mosquito species in the Florida Keys district, performs abatement, and is located in the Florida Keys, Florida, USA.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">Florida Keys Mosquito Control district organization</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043234">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of Cyp4j5 L43F</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043236">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>lurex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043237">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>tick specimen collection process by citizen scientists</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043238">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Geolocation provenance information that specifies that data were provided directly from a source, rather than estimated or calculated.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001143</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/323</obo:IAO_0000233>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label>geolocation provision information</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043239">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Geolocation provenance information that specifies that the number of decimal places in the data were truncated.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001155</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/323</obo:IAO_0000233>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label>geolocation obfuscation information</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043240">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Geolocation provenance information that specifies that data were calculated by the curator or found using a geolocation lookup service.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001141</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/323</obo:IAO_0000233>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label>geolocation estimation information from curator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043241">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Geolocation provenance information that specifies that data were estimated using information about an administrative region.</obo:IAO_0000115>
+        <obo:IAO_0000116>Usually this means an arbitrary or centroid location within that country, or the results of a geocoding service.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001156</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/323</obo:IAO_0000233>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label>geolocation estimation from administrative region information</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043242">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Geolocation provenance information that specifies that data were estimated from information about an administrative region of first order or higher.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001157</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/323</obo:IAO_0000233>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label>geolocation data estimation information from first- or higher-order administrative region</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043243">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Geolocation provenance information that specifies that data were estimated from from information about an administrative region of second order or higher.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001158</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/323</obo:IAO_0000233>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label>geolocation estimation information from second- or higher-order administrative region</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043244">
+        <obo:IAO_0000115>Geolocation provenance information that specifies that data were estimated from a street address or landmark.</obo:IAO_0000115>
+        <obo:IAO_0000116>Usually this will be the result of a geocoding service.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VBcv:0001159</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/323</obo:IAO_0000233>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label>geolocation estimation information from street address or landmark</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043247">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/442</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Sarah Kelly</dc:contributor>
+        <rdfs:label xml:lang="en">Anopheles nuneztovari sensu lato</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043254">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/462</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Sarah Kelly</dc:contributor>
+        <rdfs:label xml:lang="en">Anaplasma phagocytophilum str. Ap-ha</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043255">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/462</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Sarah Kelly</dc:contributor>
+        <rdfs:label xml:lang="en">Anaplasma phagocytophilum str. Ap-v1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043256">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001015>yes</obo:EUPATH_0001015>
+        <obo:IAO_0000115>The date on which specimen collection began</obo:IAO_0000115>
+        <rdfs:label>specimen collection start date</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043257">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001015>yes</obo:EUPATH_0001015>
+        <obo:IAO_0000115>The date on which specimen collection ended</obo:IAO_0000115>
+        <rdfs:label>specimen collection end date</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043258">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">5</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>If there was a period of time between the start and end dates that no collections were made, this will be indicated by &apos;Yes&apos;.</obo:IAO_0000115>
+        <rdfs:label>dates are discontinuous</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043263">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40003423</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Anopheles pollicaris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043264">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40000247</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Armigeres magnus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043265">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40000251</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Armigeres traubi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043266">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40002490</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Culex alis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043267">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40002718</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Culex whitei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043268">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/527</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Anopheles culicifacies BCE subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043269">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40001012</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Aedes condolescens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043270">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40000104</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Anopheles grabhamii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043271">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40003399</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Anopheles hodgkini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/EUPATH_0043272">
+        <obo:IAO_0000116>This species is not in NCBITaxon so is assigned a EUPATH ID.</obo:IAO_0000116>
+        <obo:IAO_0000117>Jie Zheng https://orcid.org/0000-0002-2999-0103</obo:IAO_0000117>
+        <obo:IAO_0000119>MIRO:40000142</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/535</obo:IAO_0000233>
+        <obo:IAO_0000234>PopBio</obo:IAO_0000234>
+        <dc:contributor>Bob MacCallum</dc:contributor>
+        <rdfs:label xml:lang="en">Anopheles namibiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/FOODON_00001287">
+        <obo:IAO_0000115 xml:lang="en">A mushroom (or toadstool) is the fleshy, spore-bearing fruiting body of a fungus, typically produced above ground on soil or on its food source.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/foodon.owl"/>
+        <rdfs:label xml:lang="en">mushroom (whole organism)</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00000013">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</obo:EUPATH_0000274>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:comment>This variable will be auto-populated at load time by looking up GADM polygons.</rdfs:comment>
+        <rdfs:label>continent</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00000448">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <obo:clinEpi_label>Geographic location</obo:clinEpi_label>
+        <rdfs:label>Collection site</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/GAZ_00001102">
+        <obo:IAO_0000115>A landlocked country in East Africa, bordered on the east by Kenya, the north by Sudan, on the west by the Democratic Republic of the Congo, on the southwest by Rwanda, and on the south by Tanzania. The southern part of the country includes a substantial portion of Lake Victoria, within which it shares borders with Kenya and Tanzania. Uganda is divided into 80 districts, spread across four administrative regions: Northern, Eastern, Central and Western. The districts are subdivided into counties.</obo:IAO_0000115>
+        <rdfs:label>Uganda</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000002">
+        <obo:IAO_0000111 xml:lang="en">example to be eventually removed</obo:IAO_0000111>
+        <rdfs:label xml:lang="en">example to be eventually removed</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000003">
+        <rdfs:comment>Child terms were not in EUPATH ontology</rdfs:comment>
+        <rdfs:label>Units</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000004">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has measurement value</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000039">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has measurement unit label</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000078">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Qualifier providing information about the species/taxonomic assignment based on potentially multiple species identification assays performed on the same specimen. &apos;unambiguous&apos; indicates that the assignment could be made without any contradictory results. &apos;ambiguous&apos; indicates that a higher-level taxonomic term had to be used because of conflicting results. &apos;fallback&apos; indicates that no assay results were used and a dataset-wide default taxon was used.</obo:IAO_0000115>
+        <rdfs:label>species qualifier</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000103">
+        <obo:IAO_0000111 xml:lang="en">failed exploratory term</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">The term was used in an attempt to structure part of the ontology but in retrospect failed to do a good job</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">failed exploratory term</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000120">
+        <obo:IAO_0000111 xml:lang="en">metadata complete</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Class has all its metadata, but is either not guaranteed to be in its final location in the asserted IS_A hierarchy or refers to another class that is not complete.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">metadata complete</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000121">
+        <obo:IAO_0000111 xml:lang="en">organizational term</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Term created to ease viewing/sort terms for development purpose, and will not be included in a release</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">organizational term</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000122">
+        <obo:IAO_0000111 xml:lang="en">ready for release</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Class has undergone final review, is ready for use, and will be included in the next release. Any class lacking &quot;ready_for_release&quot; should be considered likely to change place in hierarchy, have its definition refined, or be obsoleted in the next release.  Those classes deemed &quot;ready_for_release&quot; will also derived from a chain of ancestor classes that are also &quot;ready_for_release.&quot;</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">ready for release</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000123">
+        <obo:IAO_0000111 xml:lang="en">metadata incomplete</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Class is being worked on; however, the metadata (including definition) are not complete or sufficiently clear to the branch editors.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">metadata incomplete</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000124">
+        <obo:IAO_0000111 xml:lang="en">uncurated</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Nothing done yet beyond assigning a unique class ID and proposing a preferred term.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">uncurated</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000125">
+        <obo:IAO_0000111 xml:lang="en">pending final vetting</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">All definitions, placement in the asserted IS_A hierarchy and required minimal metadata are complete. The class is awaiting a final review by someone other than the term editor.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">pending final vetting</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000136">
+        <obo:IAO_0000112 xml:lang="en">This document is about information artifacts and their representations</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000125"/>
+        <obo:IAO_0000115 xml:lang="en">A (currently) primitive relation that relates an information artifact to an entity.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">7/6/2009 Alan Ruttenberg. Following discussion with Jonathan Rees, and introduction of &quot;mentions&quot; relation. Weaken the is_about relationship to be primitive. 
+
+We will try to build it back up by elaborating the various subproperties that are more precisely defined.
+
+Some currently missing phenomena that should be considered &quot;about&quot; are predications - &quot;The only person who knows the answer is sitting beside me&quot; , Allegory, Satire, and other literary forms that can be topical without explicitly mentioning the topic.</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Smith, Ceusters, Ruttenberg, 2000 years of philosophy</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">is about</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000142">
+        <obo:IAO_0000115>An information artifact IA mentions an entity E exactly when it has a component/part that denotes E</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label>mentions</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000219">
+        <obo:IAO_0000112 xml:lang="en">A person&apos;s name denotes the person. A variable name in a computer program denotes some piece of memory. Lexically equivalent strings can denote different things, for instance &quot;Alan&quot; can denote different people. In each case of use, there is a case of the denotation relation obtaining, between &quot;Alan&quot; and the person that is being named.</obo:IAO_0000112>
+        <obo:IAO_0000115 xml:lang="en">A primitive, instance-level, relation obtaining between an information content entity and some portion of reality. Denotation is what happens when someone creates an information content entity E in order to specifically refer to something. The only relation between E and the thing is that E can be used to &apos;pick out&apos; the thing. This relation connects those two together. Freedictionary.com sense 3: To signify directly; refer to specifically</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">2009-11-10 Alan Ruttenberg. Old definition said the following to emphasize the generic nature of this relation. We no longer have &apos;specifically denotes&apos;, which would have been primitive, so make this relation primitive.
+g denotes r =def 
+r is a portion of reality
+there is some c that is a concretization of g 
+every c that is a concretization of g specifically denotes r</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">Conversations with Barry Smith, Werner Ceusters, Bjoern Peters, Michel Dumontier, Melanie Courtot, James Malone, Bill Hogan</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:comment xml:lang="en"></rdfs:comment>
+        <rdfs:label xml:lang="en">denotes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000221">
+        <obo:IAO_0000115 xml:lang="en">m is a quality measurement of q at t. When q is a quality, there is a measurement process p that has specified output m, a measurement datum, that is about q</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">8/6/2009 Alan Ruttenberg: The strategy is to be rather specific with this relationship. There are other kinds of measurements that are not of qualities, such as those that measure time. We will add these as separate properties for the moment and see about generalizing later</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">From the second IAO workshop [Alan Ruttenberg 8/6/2009: not completely current, though bringing in comparison is probably important]
+
+This one is the one we are struggling with at the moment. The issue is what a measurement measures. On the one hand saying that it measures the quality would include it &quot;measuring&quot; the bearer = referring to the bearer in the measurement. However this makes comparisons of two different things not possible. On the other hand not having it inhere in the bearer, on the face of it, breaks the audit trail.
+
+Werner suggests a solution based on &quot;Magnitudes&quot; a proposal for which we are awaiting details.
+--
+From the second IAO workshop, various comments, [commented on by Alan Ruttenberg 8/6/2009]
+
+unit of measure is a quality, e.g. the length of a ruler.
+
+[We decided to hedge on what units of measure are, instead talking about measurement unit labels, which are the information content entities that are about whatever measurement units are. For IAO we need that information entity in any case. See the term measurement unit label]
+
+[Some struggling with the various subflavors of is_about. We subsequently removed the relation represents, and describes until and only when we have a better theory]
+
+a represents b means either a denotes b or a describes
+
+describe:
+a describes b means a is about b and a allows an inference of at least one quality of b
+
+We have had a long discussion about denotes versus describes.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">From the second IAO workshop: An attempt at tieing the quality to the measurement datum more carefully.
+
+a is a magnitude means a is a determinate quality particular inhering in some bearer b existing at a time t that can be represented/denoted by an information content entity e that has parts denoting a unit of measure, a number, and b. The unit of measure is an instance of the determinable quality.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">From the second meeting on IAO:
+
+An attempt at defining assay using Barry&apos;s &quot;reliability&quot; wording
+
+assay:
+process and has_input some material entity
+and has_output some information content entity 
+and which is such that instances of this process type reliably generate 
+outputs that describes the input.</obo:IAO_0000116>
+        <obo:IAO_0000116 xml:lang="en">This one is the one we are struggling with at the moment. The issue is what a measurement measures. On the one hand saying that it measures the quality would include it &quot;measuring&quot; the bearer = referring to the bearer in the measurement. However this makes comparisons of two different things not possible. On the other hand not having it inhere in the bearer, on the face of it, breaks the audit trail.
+
+Werner suggests a solution based on &quot;Magnitudes&quot; a proposal for which we are awaiting details.</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">is quality measurement of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000224">
+        <obo:IAO_0000115 xml:lang="en">Core is an instance of a grouping of terms from an ontology or ontologies. It is used by the ontology to identify main classes.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000231 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000226"/>
+        <rdfs:label xml:lang="en">obsolete_core</rdfs:label>
+        <owl:deprecated rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</owl:deprecated>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000226">
+        <obo:IAO_0000111 xml:lang="en">placeholder removed</obo:IAO_0000111>
+        <rdfs:label xml:lang="en">placeholder removed</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000227">
+        <obo:IAO_0000111 xml:lang="en">terms merged</obo:IAO_0000111>
+        <obo:IAO_0000116 xml:lang="en">An editor note should explain what were the merged terms and the reason for the merge.</obo:IAO_0000116>
+        <rdfs:label xml:lang="en">terms merged</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000228">
+        <obo:IAO_0000111 xml:lang="en">term imported</obo:IAO_0000111>
+        <obo:IAO_0000116 xml:lang="en">This is to be used when the original term has been replaced by a term imported from an other ontology. An editor note should indicate what is the URI of the new term to use.</obo:IAO_0000116>
+        <rdfs:label xml:lang="en">term imported</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000229">
+        <obo:IAO_0000111 xml:lang="en">term split</obo:IAO_0000111>
+        <obo:IAO_0000116 xml:lang="en">This is to be used when a term has been split in two or more new terms. An editor note should indicate the reason for the split and indicate the URIs of the new terms created.</obo:IAO_0000116>
+        <rdfs:label xml:lang="en">term split</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000235">
+        <obo:IAO_0000115 xml:lang="en">inverse of the relation &apos;denotes&apos;</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person: Jie Zheng, Chris Stoeckert, Mike Conlon</obo:IAO_0000117>
+        <obo:IAO_0000233 rdf:resource="https://github.com/information-artifact-ontology/IAO/issues/206"/>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">denoted by</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000311">
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:comment>Note, like &quot;Designs and Tags&quot; these values are unlikely to be loaded into EDA tables. They are here to prevent loader errors.</rdfs:comment>
+        <rdfs:label>Publication status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000404">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">has x coordinate value</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000407">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:comment xml:lang="en">relating a cartesian spatial coordinate datum to a unit label that together with the values represent a point</rdfs:comment>
+        <rdfs:label xml:lang="en">has coordinate unit label</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000410">
+        <obo:IAO_0000111 xml:lang="en">universal</obo:IAO_0000111>
+        <obo:IAO_0000116 xml:lang="en">Hard to give a definition for. Intuitively a &quot;natural kind&quot; rather than a collection of any old things, which a class is able to be, formally. At the meta level, universals are defined as positives, are disjoint with their siblings, have single asserted parents.</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">A Formal Theory of Substances, Qualities, and Universals, http://ontology.buffalo.edu/bfo/SQU.pdf</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">universal</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000413">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 xml:lang="en">relates a process to a time-measurement-datum that represents the duration of the process</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">is duration of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000417">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115 xml:lang="en">inverse of the relation of is quality measurement of</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">2009/10/19 Alan Ruttenberg. Named &apos;junk&apos; relation useful in restrictions, but not a real instance relationship</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/iao.owl"/>
+        <rdfs:label xml:lang="en">is quality measured as</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000420">
+        <obo:IAO_0000111 xml:lang="en">defined class</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A defined class is a class that is defined by a set of logically necessary and sufficient conditions but is not a universal</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">&quot;definitions&quot;, in some readings, always are given by necessary and sufficient conditions. So one must be careful (and this is difficult sometimes) to distinguish between defined classes and universal.</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">defined class</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000421">
+        <obo:IAO_0000111 xml:lang="en">named class expression</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A named class expression is a logical expression that is given a name. The name can be used in place of the expression.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">named class expressions are used in order to have more concise logical definition but their extensions may not be interesting classes on their own. In languages such as OWL, with no provisions for macros, these show up as actuall classes. Tools may with to not show them as such, and to replace uses of the macros with their expansions</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <rdfs:label xml:lang="en">named class expression</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000423">
+        <obo:IAO_0000111 xml:lang="en">to be replaced with external ontology term</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">Terms with this status should eventually replaced with a term from another ontology.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">to be replaced with external ontology term</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000428">
+        <obo:IAO_0000111 xml:lang="en">requires discussion</obo:IAO_0000111>
+        <obo:IAO_0000115 xml:lang="en">A term that is metadata complete, has been reviewed, and problems have been identified that require discussion before release. Such a term requires editor note(s) to identify the outstanding issues.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">group:OBI</obo:IAO_0000119>
+        <rdfs:label xml:lang="en">requires discussion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IAO_0000445">
+        <rdfs:label xml:lang="en">in preparation</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IRO_0000027">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>ABC trap catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/IRO_0000194">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>exit trap catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/MIRO_10000239">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>group1.insecticidal substance</rdfs:label>
+        <rdfs:label>insecticidal substance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_100177">
+        <rdfs:label>Borreliella lusitaniae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_100677">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pseudovishnui</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_100678">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex vishnui</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10114">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>rat</obo:IAO_0000118>
+        <obo:IAO_0000118>rats</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rattus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10116">
+        <obo:IAO_0000118>Mus norvegicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Norway rat</obo:IAO_0000118>
+        <obo:IAO_0000118>brown rat</obo:IAO_0000118>
+        <obo:IAO_0000118>rat</obo:IAO_0000118>
+        <obo:IAO_0000118>rats</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rattus norvegicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10117">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Mus rattus</obo:IAO_0000118>
+        <obo:IAO_0000118>Rattus rattoides</obo:IAO_0000118>
+        <obo:IAO_0000118>Rattus wroughtoni</obo:IAO_0000118>
+        <obo:IAO_0000118>black rat</obo:IAO_0000118>
+        <obo:IAO_0000118>house rat</obo:IAO_0000118>
+        <obo:IAO_0000118>roof rat</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rattus rattus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_102285">
+        <obo:IAO_0000118>Hymenolepis nana</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rodentolepis nana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10239">
+        <obo:IAO_0000118>Vira</obo:IAO_0000118>
+        <obo:IAO_0000118>Viridae</obo:IAO_0000118>
+        <obo:IAO_0000118>viruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Viruses</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_102899">
+        <obo:IAO_0000118>woodland malaria mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles punctipennis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10358">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cytomegalovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1038078">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia bonneae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10405">
+        <obo:IAO_0000118>mammalian hepatitis B-type viruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthohepadnavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10407">
+        <obo:IAO_0000118>HBV</obo:IAO_0000118>
+        <obo:IAO_0000118>Human hepatitis B virus</obo:IAO_0000118>
+        <obo:IAO_0000118>hepatitis B virus (HBV)</obo:IAO_0000118>
+        <obo:IAO_0000118>hepatitis B virus HBV</obo:IAO_0000118>
+        <obo:IAO_0000118>hepatitis B virus, HBV</obo:IAO_0000118>
+        <obo:IAO_0000118>human hepatitis B virus HBV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Hepatitis B virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_104516">
+        <obo:IAO_0000118>Aedes hendersoni</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus henderson</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus hendersoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1050223">
+        <rdfs:label>Ixodes acuminatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10508">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Adenoviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1056966">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_107326">
+        <obo:IAO_0000118>Anopheles jeyporensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles jeyporiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1073269">
+        <obo:IAO_0000118>Balantidium cf. coli</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Balantioides cf. coli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_108405">
+        <obo:IAO_0000118>Common tern</obo:IAO_0000118>
+        <obo:IAO_0000118>Flussseeschwalbe</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sterna hirundo</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1085685">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex atratus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1085687">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex abominator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1085688">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex cedecei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1085689">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex iolambdis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1085690">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex mulrennani</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1085691">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex peccator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1088130">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Cervus timorensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Javan rusa</obo:IAO_0000118>
+        <obo:IAO_0000118>Sunda sambar</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rusa timorensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_108840">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Pipra striata</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pardalotus striatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1089792">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Iodamoeba</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_10912">
+        <obo:IAO_0000118>Rotaviruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_109668">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles lesteri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11019">
+        <obo:IAO_0000118>Alphaviridae</obo:IAO_0000118>
+        <obo:IAO_0000118>arboviruses group A</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Alphavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11021">
+        <obo:IAO_0000118>Eastern equine encephalomyelitis virus</obo:IAO_0000118>
+        <obo:IAO_0000118>eastern equine encephalomyelitis EEE</obo:IAO_0000118>
+        <obo:IAO_0000118>eastern equine encephalomyelitis virus EEEV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eastern equine encephalitis virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11024">
+        <rdfs:label>Highlands J virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11039">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Western equine encephalomyelitis virus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Western equine encephalitis virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11050">
+        <obo:IAO_0000118>Flavivirus (arbovirus group B)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Flaviviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11051">
+        <obo:IAO_0000118>arboviruses group B</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Flavivirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_110671">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Ardea virescens</obo:IAO_0000118>
+        <obo:IAO_0000118>green heron</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Butorides virescens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_110766">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Entamoeba coli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_110788">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Endolimax nana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11080">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>St. Louis encephalitis virus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Saint Louis encephalitis virus</rdfs:label>
+        <rdfs:label>St. Louis encephalitis virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11082">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>WNV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>West Nile virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11083">
+        <rdfs:label>Powassan virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_110926">
+        <obo:IAO_0000118>Anas columbianus</obo:IAO_0000118>
+        <obo:IAO_0000118>Olor columbianus</obo:IAO_0000118>
+        <obo:IAO_0000118>tundra swan</obo:IAO_0000118>
+        <obo:IAO_0000118>whistling swan</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cygnus columbianus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11102">
+        <obo:IAO_0000118>Hepatitis C virus group</obo:IAO_0000118>
+        <obo:IAO_0000118>Hepatitis C viruses</obo:IAO_0000118>
+        <obo:IAO_0000118>Hepatitis C-like viruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Hepacivirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11103">
+        <obo:IAO_0000118>HCV</obo:IAO_0000118>
+        <obo:IAO_0000118>Hepatitis C virus</obo:IAO_0000118>
+        <obo:IAO_0000118>hepatitis C virus HCV</obo:IAO_0000118>
+        <obo:IAO_0000118>human hepatitis C virus</obo:IAO_0000118>
+        <obo:IAO_0000118>human hepatitis C virus HCV</obo:IAO_0000118>
+        <obo:IAO_0000118>human hepatitis virus C HCV</obo:IAO_0000118>
+        <obo:IAO_0000118>post-transfusion hepatitis non A non B virus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Hepacivirus C</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11137">
+        <obo:IAO_0000118>Coronavirus 229E</obo:IAO_0000118>
+        <obo:IAO_0000118>HCoV-229E</obo:IAO_0000118>
+        <obo:IAO_0000118>Human coronavirus (STRAIN 229E)</obo:IAO_0000118>
+        <obo:IAO_0000118>Human coronavirus serogroup 229E</obo:IAO_0000118>
+        <obo:IAO_0000118>Human coronavirus strain 229E</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human coronavirus 229E</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11157">
+        <obo:IAO_0000118>negative-sense genome single-stranded RNA viruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mononegavirales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11158">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Paramyxoviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_111615">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles fluviatilis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_111810">
+        <obo:IAO_0000118>Strix otus</obo:IAO_0000118>
+        <obo:IAO_0000118>long-eared owl</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Asio otus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_111865">
+        <obo:IAO_0000118>Fringilla noctis</obo:IAO_0000118>
+        <obo:IAO_0000118>lesser Antillean bullfinch</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Loxigilla noctis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_111991">
+        <obo:IAO_0000118>Fringilla bicolor</obo:IAO_0000118>
+        <obo:IAO_0000118>Tiaris bicolor</obo:IAO_0000118>
+        <obo:IAO_0000118>black-faced grassquit</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Melanospiza bicolor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11216">
+        <obo:IAO_0000118>HPIV-3</obo:IAO_0000118>
+        <obo:IAO_0000118>HPIV3</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza 3 virus</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus type 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Parainfluenza virus type 3</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus 3 HPIV3</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus type 3 PIV3</obo:IAO_0000118>
+        <obo:IAO_0000118>parainfluenza virus type 3 PIV-3</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human respirovirus 3</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_112264">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>fluviatilis species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_112265">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles fluviatilis S</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_112266">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles fluviatilis T</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_112268">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles minimus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11234">
+        <obo:IAO_0000118>Cell-associated subacute sclerosing panencephalitis</obo:IAO_0000118>
+        <obo:IAO_0000118>Measles virus</obo:IAO_0000118>
+        <obo:IAO_0000118>Subacute sclerosing panencephalitis virus</obo:IAO_0000118>
+        <obo:IAO_0000118>measles virus MV</obo:IAO_0000118>
+        <obo:IAO_0000118>rougeole virus</obo:IAO_0000118>
+        <obo:IAO_0000118>rubeola virus</obo:IAO_0000118>
+        <obo:IAO_0000118>subacute sclerose panencephalitis virus</obo:IAO_0000118>
+        <obo:IAO_0000118>subacute sclerosing panencephalitis virus, SSPEV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Measles morbillivirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11244">
+        <obo:IAO_0000118>Pneumovirinae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pneumoviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11250">
+        <obo:IAO_0000118>HRSV</obo:IAO_0000118>
+        <obo:IAO_0000118>Human respiratory syncytial virus</obo:IAO_0000118>
+        <obo:IAO_0000118>human RSV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human orthopneumovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1129559">
+        <obo:IAO_0000118>Aedes (Ochlerotatus) diantaeus</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes diantaeus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus diantaeus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11308">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthomyxoviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11320">
+        <obo:IAO_0000118>FLUAV</obo:IAO_0000118>
+        <obo:IAO_0000118>Human Influenza A Virus</obo:IAO_0000118>
+        <obo:IAO_0000118>Influenza virus type A</obo:IAO_0000118>
+        <obo:IAO_0000118>influenza A virus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Influenza A virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1141471">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pretoriensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1141472">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles rufipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1141473">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles theileri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_114277">
+        <rdfs:label>spotted fever group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_114292">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>typhus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11520">
+        <obo:IAO_0000118>FLUBV</obo:IAO_0000118>
+        <obo:IAO_0000118>Influenza virus type B</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Influenza B virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11552">
+        <obo:IAO_0000118>FLUCV</obo:IAO_0000118>
+        <obo:IAO_0000118>Influenza C viruses</obo:IAO_0000118>
+        <obo:IAO_0000118>Influenza virus type C</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Influenza C virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_115703">
+        <obo:IAO_0000118>eared dove</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Zenaida auriculata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11577">
+        <obo:IAO_0000118>Bunyavirus la crosse</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>La Crosse virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11646">
+        <obo:IAO_0000118>Lentivirinae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lentivirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11676">
+        <obo:IAO_0000118>AIDS virus</obo:IAO_0000118>
+        <obo:IAO_0000118>HIV</obo:IAO_0000118>
+        <obo:IAO_0000118>HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>HIV1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human immunodeficiency virus type 1</obo:IAO_0000118>
+        <obo:IAO_0000118>LAV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus 1 HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus type 1 HIV 1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus type 1 HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus type 1 HIV1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus type 1, HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus type I HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus type-1 HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human immunodeficiency virus-1 HIV-1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human immunodeficiency virus 1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_117571">
+        <obo:IAO_0000118>bony vertebrates</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Euteleostomi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_119089">
+        <obo:IAO_0000118>Adenophorea</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chromadorea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_119225">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Protomacleaya</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1197337">
+        <obo:IAO_0000118>Aedes theobaldi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus theobaldi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11974">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Caliciviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_11983">
+        <obo:IAO_0000118>Norwalk calicivirus</obo:IAO_0000118>
+        <obo:IAO_0000118>Norwalk virus NV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Norwalk virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1199414">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles neomaculipalpus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12022">
+        <obo:IAO_0000118>Bacteriophage MS2</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterobacteria phage MS2</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterobacterio phage MS2</obo:IAO_0000118>
+        <obo:IAO_0000118>phage MS2</obo:IAO_0000118>
+        <obo:IAO_0000118>xLevivirus subgroup I</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Escherichia phage MS2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12058">
+        <obo:IAO_0000118>Picornavirus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Picornaviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12059">
+        <obo:IAO_0000118>Enteroviruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205936">
+        <obo:IAO_0000118>Aedes atlanticus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus atlanticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205938">
+        <obo:IAO_0000118>Aedes increpitus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus increpitus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205941">
+        <obo:IAO_0000118>Aedes niphadopsis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus niphadopsis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205942">
+        <obo:IAO_0000118>Aedes sierrensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus sierrensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205943">
+        <obo:IAO_0000118>Aedes spencerii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus spencerii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205944">
+        <obo:IAO_0000118>Aedes thelcter</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus thelcter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205945">
+        <obo:IAO_0000118>Aedes thibaulti</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus thibaulti</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1205946">
+        <obo:IAO_0000118>Aedes tortilis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus tortilis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206013">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora longipalpus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206014">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora pygmaea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206015">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora signipennis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206036">
+        <obo:IAO_0000118>Aedes zoosophus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus zoosophus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206047">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex bahamensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206282">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta particeps</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206287">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora discolor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206303">
+        <obo:IAO_0000118>Aedes mitchellae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus mitchellae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206307">
+        <obo:IAO_0000118>Aedes schizopinax</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus schizopinax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206794">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ecdysozoa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1206795">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lophotrochozoa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12080">
+        <obo:IAO_0000118>HPV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human poliovirus 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human poliovirus type 1</obo:IAO_0000118>
+        <obo:IAO_0000118>PV1</obo:IAO_0000118>
+        <obo:IAO_0000118>Polio virus 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Poliovirus type 1</obo:IAO_0000118>
+        <obo:IAO_0000118>poliovirus type 1 PV1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Poliovirus 1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12082">
+        <obo:IAO_0000118>Poliovirus type 1 (strain Sabin)</obo:IAO_0000118>
+        <obo:IAO_0000118>human poliovirus strain Sabin 1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human poliovirus 1 strain Sabin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12083">
+        <obo:IAO_0000118>HPV-2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human Poliovirus type 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human poliovirus 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Poliovirus type 2</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Poliovirus 2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12086">
+        <obo:IAO_0000118>HPV-3</obo:IAO_0000118>
+        <obo:IAO_0000118>Human poliovirus 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Human poliovirus type 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Polio virus 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Poliovirus serotype 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Poliovirus type 3</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Poliovirus 3</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120868">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles claviger</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120869">
+        <obo:IAO_0000118>Aedes cantans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus cantans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120870">
+        <obo:IAO_0000118>Aedes caspius</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus caspius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120871">
+        <obo:IAO_0000118>Aedes cataphylla</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus cataphylla</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120872">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes cinereus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120873">
+        <obo:IAO_0000118>Aedes detritus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus detritus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120874">
+        <obo:IAO_0000118>Aedes (Finlaya) geniculatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus (Finlaya) geniculatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus geniculatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes geniculatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120876">
+        <obo:IAO_0000118>Aedes pullatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus pullatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120877">
+        <obo:IAO_0000118>Aedes rusticus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus rusticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_120878">
+        <obo:IAO_0000118>Aedes sticticus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus sticticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1212470">
+        <obo:IAO_0000118>Dendroica striata</obo:IAO_0000118>
+        <obo:IAO_0000118>black-poll warbler</obo:IAO_0000118>
+        <obo:IAO_0000118>blackpoll warbler</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Setophaga striata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1214271">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes vexans nipponii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1216928">
+        <rdfs:label>Heartland virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1224">
+        <obo:IAO_0000118>&quot;Alphaproteobacteriota&quot; Whitman et al. 2018</obo:IAO_0000118>
+        <obo:IAO_0000118>Alphaproteobacteriota</obo:IAO_0000118>
+        <obo:IAO_0000118>Proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>Proteobacteriota</obo:IAO_0000118>
+        <obo:IAO_0000118>proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>purple photosynthetic bacteria and relatives</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudomonadota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_122928">
+        <obo:IAO_0000118>Human calicivirus genogroup 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Norovirus genogroup 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Norovirus genogroup I</obo:IAO_0000118>
+        <obo:IAO_0000118>Norwalk-like virus genogroup 1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Norovirus GI</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_122929">
+        <obo:IAO_0000118>Norovirus genogroup 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Norovirus genogroup II</obo:IAO_0000118>
+        <obo:IAO_0000118>Norwalk-like virus genogroup 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Norwalk-like viruses genogroup 2</obo:IAO_0000118>
+        <obo:IAO_0000118>human calicivirus genogroup 2</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Norovirus GII</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1236">
+        <obo:IAO_0000118>Proteobacteria gamma subdivision</obo:IAO_0000118>
+        <obo:IAO_0000118>Purple bacteria, gamma subdivision</obo:IAO_0000118>
+        <obo:IAO_0000118>g-proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>gamma proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>gamma subdivision</obo:IAO_0000118>
+        <obo:IAO_0000118>gamma subgroup</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Gammaproteobacteria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_123673">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pampanai</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1239">
+        <obo:IAO_0000118>&quot;Firmicutes&quot; corrig. Gibbons and Murray 1978 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillaeota</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillota corrig. Gibbons and Murray 2021</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus/Clostridium group</obo:IAO_0000118>
+        <obo:IAO_0000118>Clostridium group firmicutes</obo:IAO_0000118>
+        <obo:IAO_0000118>Firmicuteota</obo:IAO_0000118>
+        <obo:IAO_0000118>Firmicutes</obo:IAO_0000118>
+        <obo:IAO_0000118>Low G+C firmicutes</obo:IAO_0000118>
+        <obo:IAO_0000118>clostridial firmicutes</obo:IAO_0000118>
+        <obo:IAO_0000118>firmicutes</obo:IAO_0000118>
+        <obo:IAO_0000118>low G+C Gram-positive bacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>low GC Gram+</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacillota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1245327">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia crassipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1245328">
+        <obo:IAO_0000118>Coquillettidia (Coquillettidia) richiardii</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex richiardii</obo:IAO_0000118>
+        <obo:IAO_0000118>Mansonia richiardii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia richiardii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1245347">
+        <obo:IAO_0000118>Aedes khazani</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phagomyia khazani</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1245360">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Armigeres flavus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1245386">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phagomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_124916">
+        <obo:IAO_0000118>Armigeres</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Armigeres &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_124917">
+        <obo:IAO_0000118>Culex subalbatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Armigeres subalbatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12637">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dengue virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_126679">
+        <obo:IAO_0000118>Larus atricilla</obo:IAO_0000118>
+        <obo:IAO_0000118>Laughing gull</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Leucophaeus atricilla</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_126683">
+        <obo:IAO_0000118>ring-bill gull</obo:IAO_0000118>
+        <obo:IAO_0000118>ring-billed gull</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Larus delawarensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12730">
+        <obo:IAO_0000118>HPIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>HPIV1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza 1 virus</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus type 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Parainfluenza virus type 1</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus type 1 HPIV-1</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus type 1 hPIV1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human respirovirus 1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1279">
+        <obo:IAO_0000118>Aurococcus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Staphylococcus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_127906">
+        <obo:IAO_0000118>Vibrio cholerae serogroup O1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vibrio cholerae O1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1280">
+        <obo:IAO_0000118>Micrococcus aureus</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus pyogenes</obo:IAO_0000118>
+        <obo:IAO_0000118>Staphlococcus pyogenes citreus</obo:IAO_0000118>
+        <obo:IAO_0000118>Staphylococcus aureus subsp. anaerobius</obo:IAO_0000118>
+        <obo:IAO_0000118>Staphylococcus pyogenes aureus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Staphylococcus aureus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12814">
+        <obo:IAO_0000118>RSV</obo:IAO_0000118>
+        <obo:IAO_0000118>respiratory syncytial virus RS</obo:IAO_0000118>
+        <obo:IAO_0000118>respiratory syncytial virus RS virus</obo:IAO_0000118>
+        <obo:IAO_0000118>respiratory syncytial virus RSV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Respiratory syncytial virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1282">
+        <obo:IAO_0000118>Albococcus epidermidis</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus epidermidis</obo:IAO_0000118>
+        <obo:IAO_0000118>Staphylococcus epidermidis albus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Staphylococcus epidermidis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1284620">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles nitidus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1285602">
+        <obo:IAO_0000118>Aedes fulvus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus fulvus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1288825">
+        <obo:IAO_0000118>Shigella flexneri serotype 2b</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 2b</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1289136">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Juppius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1289137">
+        <obo:IAO_0000118>Aedes juppi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus juppi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1289171">
+        <obo:IAO_0000118>Aedes caballus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus caballus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1291063">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles argyropus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12967">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Blastocystis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_12968">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Blastocystis hominis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1300248">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles vinckei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1301">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_130309">
+        <obo:IAO_0000118>HAdV-F</obo:IAO_0000118>
+        <obo:IAO_0000118>Human adenovirus F</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human mastadenovirus F</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1313">
+        <obo:IAO_0000118>Diplococcus pneumoniae</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus pneumoniae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus pneumoniae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1314">
+        <obo:IAO_0000118>Micrococcus scarlatinae</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus erysipelatos</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus hemolyticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus scarlatinae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus pyogenes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_13146">
+        <obo:IAO_0000118>Melopsittacus unduratus</obo:IAO_0000118>
+        <obo:IAO_0000118>Psittacus undulatus</obo:IAO_0000118>
+        <obo:IAO_0000118>budgerigar</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Melopsittacus undulatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1320">
+        <obo:IAO_0000118>Streptococcus group G</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus sp. (group G)</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus sp. group G</obo:IAO_0000118>
+        <obo:IAO_0000118>group G streptococcus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus sp. &apos;group G&apos;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_13203">
+        <obo:IAO_0000118>Phlebotomus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_13204">
+        <obo:IAO_0000118>Phlebotomus (Larroussius) perniciosus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus perniciosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_13248">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhodnius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_13249">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhodnius prolixus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_132724">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus similis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1344959">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Citrobacter freundii complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1350">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterococcus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1351">
+        <obo:IAO_0000118>Enterococcus proteiformis</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterocoque</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus ovalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus zymogenes</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus faecalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus glycerinaceus</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus liquefaciens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterococcus faecalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1352">
+        <obo:IAO_0000118>Streptococcus faecium</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterococcus faecium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_135621">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudomonadaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_136">
+        <obo:IAO_0000118>spirochetes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Spirochaetales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1379452">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Protoculex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1379453">
+        <obo:IAO_0000118>Aedes tormentor</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus tormentor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138">
+        <rdfs:label>Borrelia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1385">
+        <obo:IAO_0000118>Bacillus/Staphylococcus group</obo:IAO_0000118>
+        <obo:IAO_0000118>Caryophanales</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacillales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138531">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pseudowillmori</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138534">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles hyrcanus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138536">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles dravidicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138537">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles crawfordi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138950">
+        <obo:IAO_0000118>Enterovirus EV-C</obo:IAO_0000118>
+        <obo:IAO_0000118>Human enterovirus C</obo:IAO_0000118>
+        <obo:IAO_0000118>Poliovirus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterovirus C</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_138954">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Parechovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139">
+        <obo:IAO_0000118>Borrelia burgdorferi</obo:IAO_0000118>
+        <obo:IAO_0000118>Lyme disease spirochete</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Borreliella burgdorferi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139045">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles coustani</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139049">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles mattogrossensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139053">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthopodomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139054">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthopodomyia alba</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139055">
+        <obo:IAO_0000118>Uranotaenia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139056">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia sapphirina</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_139057">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedeomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1394984">
+        <obo:IAO_0000118>Giardia duodenalis assemblage B</obo:IAO_0000118>
+        <obo:IAO_0000118>Giardia lamblia (assemblage B)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Giardia intestinalis assemblage B</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_140438">
+        <obo:IAO_0000118>Aedes (Finlaya) japonicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus japonicus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes japonicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_140439">
+        <obo:IAO_0000118>Aedes (Finlaya) japonicus japonicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus japonicus japonicus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes japonicus japonicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1411916">
+        <obo:IAO_0000118>Phlebotomus (Larroussius) galilaeus</obo:IAO_0000118>
+        <obo:IAO_0000118>Phlebotomus perfiliewi galilaeus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus galilaeus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1424507">
+        <obo:IAO_0000118>Aedes aegypti queenslandensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes aegypti aegypti</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1424567">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes malayensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_142786">
+        <obo:IAO_0000118>Norwalk-like viruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Norovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1428">
+        <obo:IAO_0000118>Bacillus cereus var. thuringiensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus thuringiensis Berliner 1915 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacillus thuringiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_142886">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles sawadwongporni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_142887">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles vagus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_142888">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles willmori</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1430">
+        <obo:IAO_0000118>Bacillus thuringiensis (SUBSP. ISRAELENSIS)</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus thuringiensis israelensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus thuringiensis subsp. israelensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus thuringiensis var. israelensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacillus thuringiensis serovar israelensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1437010">
+        <obo:IAO_0000118>Boreotheria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Boreoeutheria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1481111">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex stigmatosoma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_149459">
+        <obo:IAO_0000118>Mansonia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia &lt;mosquitos,genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_149531">
+        <obo:IAO_0000118>Aedes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1496">
+        <obo:IAO_0000118>Bacillus difficilis</obo:IAO_0000118>
+        <obo:IAO_0000118>Clostridium difficile</obo:IAO_0000118>
+        <obo:IAO_0000118>Peptoclostridium difficile</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Clostridioides difficile</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1496333">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles maculipalpis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1502932">
+        <rdfs:label>Ixodes ariadnae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1507401">
+        <obo:IAO_0000118>Bocavirus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bocaparvovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1513">
+        <obo:IAO_0000118>Bacillus tetani</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Clostridium tetani</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1513311">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles dissidens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1513312">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles saeungae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1513313">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles wejchoochotei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1518534">
+        <obo:IAO_0000118>Anopheles gambiae M</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles coluzzii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1521113">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles demeilloni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1521115">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles hancocki</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1521116">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles marshallii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1529933">
+        <obo:IAO_0000118>Aedes (Finlaya) pseudotaeniatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes pseudotaeniatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Collessius (Alloeomyia) pseudotaeniatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex pseudotaeniatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus pseudotaeniatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Collessius pseudotaeniatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1529942">
+        <obo:IAO_0000118>Aedes (Finlaya) cogilli</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes cogilli</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus cogilli</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phagomyia cogilli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1538109">
+        <rdfs:label>Ixodes inopinatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1538645">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta fumipennis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1545690">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psittaculidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1548034">
+        <obo:IAO_0000118>Aedes (Ochlerotatus) zammitii</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes zammitii</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus zammitii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Acartomyia zammitii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1549204">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Trichoglossus haematodus moluccanus</obo:IAO_0000118>
+        <obo:IAO_0000118>rainbow lorikeet</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Trichoglossus moluccanus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1549675">
+        <obo:IAO_0000118>Galloanseri</obo:IAO_0000118>
+        <obo:IAO_0000118>ducks, geese, chickens, fowl, quail, currasows and allies</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Galloanserae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1551375">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia balfouri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_157">
+        <obo:IAO_0000118>&quot;Spironema&quot; Vuillemin 1905</obo:IAO_0000118>
+        <obo:IAO_0000118>Microspironema</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Treponema</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1578836">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles maculipennis sensu lato BTLHVDV-2014</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1581554">
+        <obo:IAO_0000118>American black scoter</obo:IAO_0000118>
+        <obo:IAO_0000118>Melanitta nigra americana</obo:IAO_0000118>
+        <obo:IAO_0000118>Oidemia Americana</obo:IAO_0000118>
+        <obo:IAO_0000118>Oidemia americana</obo:IAO_0000118>
+        <obo:IAO_0000118>Oidemia nigra americana</obo:IAO_0000118>
+        <obo:IAO_0000118>black scoter</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Melanitta americana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1582038">
+        <obo:IAO_0000118>Culex incidens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta incidens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_159154">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pulcherrimus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_160229">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Columba oenas</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_161">
+        <obo:IAO_0000118>Treponema pallidum pallidum</obo:IAO_0000118>
+        <obo:IAO_0000118>syphilis treponeme</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Treponema pallidum subsp. pallidum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1617964">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 4c</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_162145">
+        <obo:IAO_0000118>HMPV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human metapneumovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_162387">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Metapneumovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_162636">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles leesoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_162637">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles parensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_162997">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex annulirostris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_162998">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex sitiens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_163000">
+        <obo:IAO_0000118>Culex (Culex) palpalis Taylor</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex palpalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1643685">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Borreliaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1674146">
+        <obo:IAO_0000118>Borrelia mayonii</obo:IAO_0000118>
+        <obo:IAO_0000118>Candidatus Borrelia mayonii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Borreliella mayonii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1678250">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex rubinotus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1701320">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedeomyia africana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_171411">
+        <obo:IAO_0000118>Babesia sp. venatorum</obo:IAO_0000118>
+        <rdfs:label>Babesia venatorum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1716">
+        <obo:IAO_0000118>Turicella</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Corynebacterium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_173086">
+        <obo:IAO_0000118>Aedes epactius</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus epactius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_174620">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Wyeomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_174621">
+        <obo:IAO_0000118>pitcher-plant mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Wyeomyia smithii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_174825">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_174826">
+        <obo:IAO_0000118>Culiseta (Culiseta) impatiens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta impatiens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_175121">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Passeroidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1762">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mycobacteriaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1763">
+        <obo:IAO_0000118>Mycobacterium Lehmann and Neumann 1896 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mycobacterium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1769044">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes aegypti formosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_177093">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides pulicaris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_177094">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides impunctatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1773">
+        <obo:IAO_0000118>Bacillus tuberculosis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium tuberculosis</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacterium tuberculosis typus humanus</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacterium tuberculosis var. hominis</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacterium tuberculosis variant tuberculosis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mycobacterium tuberculosis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1783272">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Terrabacteria group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799668">
+        <obo:IAO_0000118>Aedeomyia (Lepiothauma) furfurea</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedeomyia furfurea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799669">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia chrysosoma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799674">
+        <obo:IAO_0000118>Aedes (Aedimorphus) hirsutus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes hirsutus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799675">
+        <obo:IAO_0000118>Culex (Culex) duttoni</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex duttoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799676">
+        <obo:IAO_0000118>Culex (Culex) simpsoni</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex simpsoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799681">
+        <obo:IAO_0000118>Culex (Culex) thalassius</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex thalassius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799682">
+        <obo:IAO_0000118>Culex (Culex) vansomereni</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex vansomereni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1799684">
+        <obo:IAO_0000118>Mimomyia (Mimomyia) splendens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mimomyia splendens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_180448">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Motacilla flava</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806171">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dobrotworskyius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806173">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedeomyia venustipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806174">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia linealis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806175">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta inconspicua</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806176">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex globocoxitus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806178">
+        <obo:IAO_0000118>Dobrotworskyius alboannulatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Finlaya alboannulatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus alboannulatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes alboannulatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806179">
+        <obo:IAO_0000118>Dobrotworskyius rubrithorax</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus rubrithorax</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes rubrithorax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806180">
+        <obo:IAO_0000118>Macleaya macmillani</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus macmillani</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes macmillani</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806181">
+        <obo:IAO_0000118>Macleaya tremula</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus tremulus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes tremulus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806182">
+        <obo:IAO_0000118>Macleaya wattensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus wattensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes wattensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806183">
+        <obo:IAO_0000118>Ochlerotatus mallochi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes mallochi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806184">
+        <obo:IAO_0000118>Aedes sagax</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus sagax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806185">
+        <obo:IAO_0000118>Aedes vittiger</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus vittiger</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806186">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Tripteroides atripes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806187">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Tripteroides tasmaniensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1806189">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Polylepidomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1808015">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex cylindricus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_181550">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Trichomonadidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1817">
+        <obo:IAO_0000118>Micropolyspora</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Nocardia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_183407">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_184770">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles peryassui</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_185573">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>ardensis group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_185578">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles nili</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186751">
+        <obo:IAO_0000118>mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles moucheti</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186802">
+        <obo:IAO_0000118>Clostridiales</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eubacteriales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1868215">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthopneumovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186826">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lactobacillales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_186938">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Respirovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1870884">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Clostridioides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_188699">
+        <obo:IAO_0000118>Aedes (Howardina) bahamensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus (Howardina) bahamensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus bahamensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes bahamensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_188700">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes polynesiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1903411">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Yersiniaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_190374">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles incertae sedis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_190376">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles atropos</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_190378">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles punctimacula</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_190385">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia lowii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_190765">
+        <obo:IAO_0000118>Ochlerotatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1928132">
+        <rdfs:label>Ixodes marxi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1931080">
+        <obo:IAO_0000118>Meliphagides</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Meliphagoidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_193510">
+        <obo:IAO_0000118>Anopheles amharicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles quadriannulatus sp. B</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles quadriannulatus B</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1935182">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri X variant</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_194">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Campylobacter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_195">
+        <obo:IAO_0000118>Campylobacter hyoilei</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio coli</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Campylobacter coli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1962408">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles maculatus sensu lato 4821</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1962409">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles minimus sensu lato 1775</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1962411">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles barbirostris sensu lato 245</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197">
+        <obo:IAO_0000118>Campylobacter fetus subsp. jejuni</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio hepaticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio jejuni</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Campylobacter jejuni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197911">
+        <obo:IAO_0000118>Influenzavirus A</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Alphainfluenzavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197912">
+        <obo:IAO_0000118>Influenzavirus B</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Betainfluenzavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_197913">
+        <obo:IAO_0000118>Influenzavirus C</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Gammainfluenzavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_1980410">
+        <rdfs:label>Bunyavirales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_199889">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>sundaicus species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_199890">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles epiroticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2">
+        <obo:IAO_0000118>Monera</obo:IAO_0000118>
+        <obo:IAO_0000118>Procaryotae</obo:IAO_0000118>
+        <obo:IAO_0000118>Prokaryota</obo:IAO_0000118>
+        <obo:IAO_0000118>Prokaryotae</obo:IAO_0000118>
+        <obo:IAO_0000118>bacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>eubacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>prokaryote</obo:IAO_0000118>
+        <obo:IAO_0000118>prokaryotes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacteria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2021401">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 5b</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2035320">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia indiana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2038102">
+        <obo:IAO_0000118>Neobalantidium</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Balantioides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_206113">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles peditaeniatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2066577">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles messeae x Anopheles daciae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2067437">
+        <obo:IAO_0000118>Aedes fulvus pallens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus fulvus pallens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2067438">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora horrida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2067443">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Catageiomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2067447">
+        <obo:IAO_0000118>Aedes dupreei</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex dupreei Coquillett, 1904</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus dupreei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2067448">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes fowleri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2067460">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes sudanensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2068716">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anatinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2068722">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anserinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_207245">
+        <obo:IAO_0000118>Diplomonadida group</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Fornicata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2081834">
+        <obo:IAO_0000118>Anopheles gambiae x Anopheles coluzzii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles coluzzii x Anopheles gambiae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_209">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Helicobacter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_209202">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles nigerrimus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_210">
+        <obo:IAO_0000118>Campylobacter pylori</obo:IAO_0000118>
+        <obo:IAO_0000118>Campylobacter pylori subsp. pylori</obo:IAO_0000118>
+        <obo:IAO_0000118>Campylobacter pyloridis</obo:IAO_0000118>
+        <obo:IAO_0000118>Helicobacter nemestrinae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Helicobacter pylori</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2104">
+        <obo:IAO_0000118>Filterable agent of primary atypical pneumonia</obo:IAO_0000118>
+        <obo:IAO_0000118>Schizoplasma pneumoniae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mycoplasmoides pneumoniae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2116661">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sylvioidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_213683">
+        <rdfs:label>Ixodes frontalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_213684">
+        <rdfs:label>Ixodes gibbosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_213849">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Campylobacterales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_215680">
+        <obo:IAO_0000118>Human rotavirus G12</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G12</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2157">
+        <obo:IAO_0000118>Archaebacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>Mendosicutes</obo:IAO_0000118>
+        <obo:IAO_0000118>Metabacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>Monera</obo:IAO_0000118>
+        <obo:IAO_0000118>Procaryotae</obo:IAO_0000118>
+        <obo:IAO_0000118>Prokaryota</obo:IAO_0000118>
+        <obo:IAO_0000118>Prokaryotae</obo:IAO_0000118>
+        <obo:IAO_0000118>archaea</obo:IAO_0000118>
+        <obo:IAO_0000118>prokaryote</obo:IAO_0000118>
+        <obo:IAO_0000118>prokaryotes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Archaea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_216372">
+        <obo:IAO_0000118>Anopheles culicifacies species D</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles culicifacies D</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_216373">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles culicifacies E</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_221566">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pharoensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_222">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Achromobacter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2259328">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles mascarensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_227531">
+        <obo:IAO_0000118>Anopheles intermedius</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles intermedius Shingarev, 1928</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles plumbeus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_228917">
+        <obo:IAO_0000118>Aedes canadensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus canadensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_228918">
+        <obo:IAO_0000118>Aedes trivittatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus trivittatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_228919">
+        <obo:IAO_0000118>Aedes stimulans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus stimulans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_228920">
+        <obo:IAO_0000118>Aedes grossbecki</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus grossbecki</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_228921">
+        <obo:IAO_0000118>Aedes intrudens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus intrudens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2320533">
+        <obo:IAO_0000118>Sergentomyia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sergentomyia &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_232374">
+        <obo:IAO_0000118>Newell&apos;s shearwater</obo:IAO_0000118>
+        <obo:IAO_0000118>Puffinus auricularis newelli</obo:IAO_0000118>
+        <obo:IAO_0000118>Puffinus puffinus newelli</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Puffinus newelli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_232555">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>crucians species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_233155">
+        <obo:IAO_0000118>Culex molestus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex pipiens f. molestus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pipiens molestus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_237895">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cryptosporidium hominis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_24">
+        <obo:IAO_0000118>Alteromonas putrefaciens</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas putrefaciens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shewanella putrefaciens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_243888">
+        <obo:IAO_0000118>American herring gull</obo:IAO_0000118>
+        <obo:IAO_0000118>Larus argentatus smithsonianus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Larus smithsonianus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2488823">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora varipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2497569">
+        <obo:IAO_0000118>Negative-strand RNA viruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Negarnaviricota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2497571">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Polyploviricotina</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2501931">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthocoronavirinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2509481">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Embecovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_251639">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pullus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_253">
+        <obo:IAO_0000118>Chryseobacterium indologenes (Yabuuchi et al. 1983) Vandamme et al. 1994</obo:IAO_0000118>
+        <obo:IAO_0000118>Flavobacterium indologenes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chryseobacterium indologenes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_254792">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansoniini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2559587">
+        <obo:IAO_0000118>RNA viruses</obo:IAO_0000118>
+        <obo:IAO_0000118>RNA viruses and viroids</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Riboviria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560076">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthoparamyxovirinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560080">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rubulavirinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560195">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthorubulavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560525">
+        <obo:IAO_0000118>HPIV-2</obo:IAO_0000118>
+        <obo:IAO_0000118>HPIV2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza 2 virus</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus type 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rubulavirus 2</obo:IAO_0000118>
+        <obo:IAO_0000118>PIV-2</obo:IAO_0000118>
+        <obo:IAO_0000118>Parainfluenza virus type 2</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human orthorubulavirus 2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2560526">
+        <obo:IAO_0000118>HPIV type 4</obo:IAO_0000118>
+        <obo:IAO_0000118>HPIV4</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus 4</obo:IAO_0000118>
+        <obo:IAO_0000118>Human parainfluenza virus type 4</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rubulavirus 4</obo:IAO_0000118>
+        <obo:IAO_0000118>Parainfluenza virus type 4</obo:IAO_0000118>
+        <obo:IAO_0000118>human parainfluenza virus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human orthorubulavirus 4</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2563468">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex aurantapex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2563597">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mimomyia mimomyiaformis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2563599">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mimomyia mediolineata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2572558">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ancylostomatoidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_257692">
+        <rdfs:label>Hyalomma excavatum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_260110">
+        <obo:IAO_0000118>Culex (Culex) australicus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex australicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2608887">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>unclassified Streptococcus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2611341">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Metamonada</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_262009">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles dthali</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_262673">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles superpictus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_262965">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus mascittii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_263">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Francisella tularensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_263595">
+        <obo:IAO_0000118>Human rotavirus G10</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G10</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_266040">
+        <rdfs:label>Hyalomma asiaticum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2663023">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia dyari</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_266337">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anthochaera</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_266366">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Merops carunculata</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anthochaera carunculata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_266367">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Merops chrysopterus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anthochaera chrysoptera</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_266418">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Certhia novaeHollandiae</obo:IAO_0000118>
+        <obo:IAO_0000118>New Holland honeyeater</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phylidonyris novaehollandiae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2665964">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cryptococcus neoformans var. grubii VNI</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_269190">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Psittacus elegans</obo:IAO_0000118>
+        <obo:IAO_0000118>crimson rosella</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Platycercus elegans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2697049">
+        <obo:IAO_0000118>2019-nCoV</obo:IAO_0000118>
+        <obo:IAO_0000118>COVID-19 virus</obo:IAO_0000118>
+        <obo:IAO_0000118>HCoV-19</obo:IAO_0000118>
+        <obo:IAO_0000118>Human coronavirus 2019</obo:IAO_0000118>
+        <obo:IAO_0000118>SARS-2</obo:IAO_0000118>
+        <obo:IAO_0000118>SARS-CoV-2</obo:IAO_0000118>
+        <obo:IAO_0000118>SARS-CoV2</obo:IAO_0000118>
+        <obo:IAO_0000118>SARS2</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Severe acute respiratory syndrome coronavirus 2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2698737">
+        <obo:IAO_0000118>SAR supergroup</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sar</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_270338">
+        <obo:IAO_0000118>Poliovirus type 3 Sabin vaccine strain</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human poliovirus 3 strain Sabin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2709557">
+        <obo:IAO_0000118>American harrier</obo:IAO_0000118>
+        <obo:IAO_0000118>Circus cyaneus hudsonius</obo:IAO_0000118>
+        <obo:IAO_0000118>Falco hudsonius</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Circus hudsonius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2732396">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthornavirae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2732406">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Kitrinoviricota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2732408">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pisuviricota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2732506">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pisoniviricetes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2732514">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Revtraviricetes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_273454">
+        <obo:IAO_0000118>Anopheles sergenti</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles sergentii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2745526">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles donaldi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2751882">
+        <obo:IAO_0000118>Rotavirus P4</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus A P4</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2751883">
+        <obo:IAO_0000118>Rotavirus P8</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus A P8</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2759">
+        <obo:IAO_0000118>Eucarya</obo:IAO_0000118>
+        <obo:IAO_0000118>Eucaryotae</obo:IAO_0000118>
+        <obo:IAO_0000118>Eukarya</obo:IAO_0000118>
+        <obo:IAO_0000118>Eukaryotae</obo:IAO_0000118>
+        <obo:IAO_0000118>eucaryotes</obo:IAO_0000118>
+        <obo:IAO_0000118>eukaryotes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eukaryota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2761511">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes ledgeri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2773399">
+        <obo:IAO_0000118>Aedes (Finlaya) poicilius</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes poicilius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_277944">
+        <obo:IAO_0000118>Coronavirus NL63</obo:IAO_0000118>
+        <obo:IAO_0000118>HCoV-NL63</obo:IAO_0000118>
+        <obo:IAO_0000118>Human coronavirus NL</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human coronavirus NL63</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2785382">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles franciscanus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28090">
+        <obo:IAO_0000118>Acinetobacter genomosp. 9</obo:IAO_0000118>
+        <obo:IAO_0000118>Acinetobacter genomospecies 9</obo:IAO_0000118>
+        <obo:IAO_0000118>Acinetobacter mesopotamicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Moraxella lwoffi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Acinetobacter lwoffii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28141">
+        <obo:IAO_0000118>Enterobacter sakazakii</obo:IAO_0000118>
+        <obo:IAO_0000118>yellow -pigmented Enterobacter cloacae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cronobacter sakazakii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28216">
+        <obo:IAO_0000118>Proteobacteria beta subdivision</obo:IAO_0000118>
+        <obo:IAO_0000118>Purple bacteria, beta subdivision</obo:IAO_0000118>
+        <obo:IAO_0000118>b-proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>beta proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>beta subdivision</obo:IAO_0000118>
+        <obo:IAO_0000118>beta subgroup</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Betaproteobacteria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28376">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anolis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28377">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Carolina anole</obo:IAO_0000118>
+        <obo:IAO_0000118>green anole</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anolis carolinensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_284565">
+        <obo:IAO_0000118>Culex (Melanoconion) spissipes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex spissipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_284566">
+        <obo:IAO_0000118>Culex opisthopus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex taeniopus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_286">
+        <obo:IAO_0000118>&quot;Chlorobacterium&quot; Guillebeau 1890, nom. rejic. Opin. 6 (not &quot;Chlorobacterium&quot; Lauterborn 1916)</obo:IAO_0000118>
+        <obo:IAO_0000118>Liquidomonas</obo:IAO_0000118>
+        <obo:IAO_0000118>Loefflerella</obo:IAO_0000118>
+        <obo:IAO_0000118>RNA similarity group I</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudomonas</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28624">
+        <obo:IAO_0000118>Aedes (Finlaya) atropalpus</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes (Georgecraigius) atropalpus</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes (Ochlerotatus) atropalpus</obo:IAO_0000118>
+        <obo:IAO_0000118>Georgecraigius atropalpus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus atropalpus</obo:IAO_0000118>
+        <obo:IAO_0000118>rock-pool mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes atropalpus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28680">
+        <obo:IAO_0000118>common pintail</obo:IAO_0000118>
+        <obo:IAO_0000118>northern pintail</obo:IAO_0000118>
+        <obo:IAO_0000118>pintail</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anas acuta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28694">
+        <obo:IAO_0000118>Colymbus marmoratus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Brachyramphus marmoratus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_287">
+        <obo:IAO_0000118>Bacillus aeruginosus</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus pyocyaneus</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium aeruginosum</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium pyocyaneum</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus pyocyaneus</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas polycolor</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas pyocyanea</obo:IAO_0000118>
+        <obo:IAO_0000118>probable synonym or variety: &quot;Pseudomonas polycolor&quot; Clara 1930</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudomonas aeruginosa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28875">
+        <obo:IAO_0000118>Group A rotaviruses</obo:IAO_0000118>
+        <obo:IAO_0000118>Rotavirus group A</obo:IAO_0000118>
+        <obo:IAO_0000118>group A rotavirus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus A</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_28901">
+        <obo:IAO_0000118>Bacillus cholerae-suis</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella cholerae-suis</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella choleraesuis</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica ser. choleraesuis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Salmonella enterica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_289301">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides obsoletus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_289302">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides scoticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_289309">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides dewulfi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_290028">
+        <obo:IAO_0000118>CoV-HKU1</obo:IAO_0000118>
+        <obo:IAO_0000118>HCoV-HKU1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human CoV/HKU1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human coronavirus HKU1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29031">
+        <obo:IAO_0000118>Phlebotomus (Phlebotomus) papatasi</obo:IAO_0000118>
+        <obo:IAO_0000118>Phlebotomus papatasii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus papatasi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29169">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ancylostoma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2918032">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles barberi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2918769">
+        <obo:IAO_0000118>Aedes inconspicuosus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex inconspicuosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2918771">
+        <obo:IAO_0000118>Hispidimyia hispida</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mimomyia hispida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_292">
+        <obo:IAO_0000118>Burkholderia cepacia genomovar I</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas cepacia</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas kingii</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas multivorans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Burkholderia cepacia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2924859">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 7a</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2926335">
+        <rdfs:label>Rhipicephalus sanguineus sensu lato</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_294">
+        <obo:IAO_0000118>Bacillus fluorescens</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus fluorescens liquefaciens</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium fluorescen</obo:IAO_0000118>
+        <obo:IAO_0000118>Liquidomonas fluorescens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudomonas fluorescens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29518">
+        <rdfs:label>Borreliella afzelii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29519">
+        <obo:IAO_0000118>Borrelia garinii</obo:IAO_0000118>
+        <rdfs:label>Borreliella garinii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_29930">
+        <obo:IAO_0000118>California black legged tick</obo:IAO_0000118>
+        <obo:IAO_0000118>western blacklegged tick</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ixodes pacificus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_2995234">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mycoplasmoides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_299630">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex decens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30065">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles koliensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30066">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles merus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30067">
+        <obo:IAO_0000118>Nyssorhynchus nuneztovari</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles nuneztovari</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30068">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles punctulatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30069">
+        <obo:IAO_0000118>Anopheles mysorensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles stephensi mysorensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles stephensi var. mysorensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Asian malaria mosquito</obo:IAO_0000118>
+        <obo:IAO_0000118>Neocellia intermedia</obo:IAO_0000118>
+        <obo:IAO_0000118>Neocellia intermedia Rothwell, 1907</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles stephensi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_301835">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles notanandai</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_303">
+        <obo:IAO_0000118>Arthrobacter siderocapsulatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus fluorescens putidus</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus putidus</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas arvilla</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas convexa</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas eisenbergii</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas incognita</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas ovalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas rugosa</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas striata</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudomonas putida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30390">
+        <obo:IAO_0000118>Fischreiher</obo:IAO_0000118>
+        <obo:IAO_0000118>grey heron</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ardea cinerea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3044782">
+        <rdfs:label>Orthoflavivirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30458">
+        <obo:IAO_0000118>owls</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Strigiformes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_30459">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Strigidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308708">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedeomyia catasticta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308709">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes fumidus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308710">
+        <obo:IAO_0000118>Anopheles jamesi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles jamesii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308711">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pallidus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308712">
+        <obo:IAO_0000118>Culex (Lutzia) fuscana</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex (Lutzia) fuscanus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex fuscanus</obo:IAO_0000118>
+        <obo:IAO_0000118>Lutzia (Metalutzia) fuscana</obo:IAO_0000118>
+        <obo:IAO_0000118>Lutzia fuscanus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lutzia fuscana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308713">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex gelidus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308715">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lophoceraomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308717">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex infantulus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308723">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex nigropunctatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308724">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex rubithoracis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308727">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ficalbiini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308731">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ficalbia minima</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308732">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia annulifera</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308733">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonioides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308734">
+        <obo:IAO_0000118>Mansonia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia &lt;mosquitos,subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308735">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia uniformis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308736">
+        <obo:IAO_0000118>Mimomyia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mimomyia &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308737">
+        <obo:IAO_0000118>Mimomyia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mimomyia &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_308740">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mimomyia chamberlaini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_310513">
+        <obo:IAO_0000118>Aedes sollicitans</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus (Ochlerotatus) sollicitans</obo:IAO_0000118>
+        <obo:IAO_0000118>eastern salt marsh mosquito</obo:IAO_0000118>
+        <obo:IAO_0000118>eastern saltmarsh mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus sollicitans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31281">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterocytozoon bieneusi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_314145">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Laurasiatheria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_314146">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Euarchontoglires</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_314147">
+        <obo:IAO_0000118>Rodents and rabbits</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Glires</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_314293">
+        <obo:IAO_0000118>Anthropoidea</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Simiiformes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_316">
+        <obo:IAO_0000118>&quot;Pseudomonas stanieri&quot; Mandel 1966</obo:IAO_0000118>
+        <obo:IAO_0000118>Achromobacter sewerinii</obo:IAO_0000118>
+        <obo:IAO_0000118>Achromobacter stutzeri</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus denitrificans II</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus nitrogenes</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus stutzeri</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas perfectomarina</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas perfectomarina (ex ZoBell and Upham 1944) Baumann et al. 1983</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas stutzeri (Lehmann and Neumann 1896) Sijderius 1946 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000118>Stutzerimonas perfectomarina</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Stutzerimonas stutzeri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_31631">
+        <obo:IAO_0000118>HCoV-OC43</obo:IAO_0000118>
+        <obo:IAO_0000118>Human coronavirus (strain OC43)</obo:IAO_0000118>
+        <obo:IAO_0000118>Human coronavirus strain OC43</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human coronavirus OC43</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_316597">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes pseudoscutellaris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317797">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex brevipalpis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317799">
+        <obo:IAO_0000118>Heizmannia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Heizmannia &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317803">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Heizmannia discrepans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317805">
+        <obo:IAO_0000118>Verrallina</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Verrallina &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317807">
+        <obo:IAO_0000118>Neomacleaya indicus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Verrallina indica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317808">
+        <obo:IAO_0000118>Fredwardsius vittatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes vittatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317811">
+        <obo:IAO_0000118>Armigeres</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Armigeres &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_317812">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Leicesteria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_319534">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles philippinensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_320069">
+        <obo:IAO_0000118>Myzomyia rossi var. indefinitus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles indefinitus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32008">
+        <obo:IAO_0000118>Pseudomonas RNA homology group II</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Burkholderia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32257">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Kingella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32523">
+        <obo:IAO_0000118>tetrapods</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Tetrapoda</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32524">
+        <obo:IAO_0000118>amniotes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Amniota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32525">
+        <obo:IAO_0000118>Theria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Theria &lt;mammals&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325427">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudoficalbia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325428">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia recondita</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325429">
+        <obo:IAO_0000118>Uranotaenia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325430">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthopodomyia anopheloides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325433">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia atra</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325434">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Malaya genurostris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325435">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia bicolor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325436">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles splendidus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325438">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Heizmannia chandi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325439">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles aitkenii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325441">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Tripteroides aranoides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_325443">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex minor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32561">
+        <obo:IAO_0000118>Diapsida</obo:IAO_0000118>
+        <obo:IAO_0000118>diapsids</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sauria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_32595">
+        <rdfs:label>Babesia divergens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_328018">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Leucophaeus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329099">
+        <obo:IAO_0000118>Aedes (Ochlerotatus) communis</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes communis</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex communis</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus (Ochlerotatus) communis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus communis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329100">
+        <obo:IAO_0000118>Aedes abserratus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus abserratus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329101">
+        <obo:IAO_0000118>Aedes aurifer</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus aurifer</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329102">
+        <obo:IAO_0000118>Aedes cantator</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus cantator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329103">
+        <obo:IAO_0000118>Aedes excrucians</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus excrucians</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329105">
+        <obo:IAO_0000118>Aedes taeniorhynchus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex taeniorhynchus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus taeniorhynchus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329106">
+        <obo:IAO_0000118>Culex cilliata</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora ciliata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329107">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta morsitans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329108">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta minnesotae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329109">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta melanura</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329110">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329111">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia perturbans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329112">
+        <obo:IAO_0000118>Megarhinus septentrionalis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Toxorhynchites rutilus septentrionalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_329641">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human bocavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33084">
+        <obo:IAO_0000118>Entamoebida</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Entamoebidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33154">
+        <obo:IAO_0000118>Fungi/Metazoa group</obo:IAO_0000118>
+        <obo:IAO_0000118>opisthokonts</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Opisthokonta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_332058">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta annulata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33213">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bilateria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33278">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ancylostomatidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33317">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Protostomia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33340">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neoptera</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33402">
+        <obo:IAO_0000118>Phlebotomus (Larroussius) tobbi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus tobbi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33554">
+        <obo:IAO_0000118>carnivores</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Carnivora</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33630">
+        <obo:IAO_0000118>alveolates</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Alveolata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_337677">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cricetidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_337687">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Muroidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_337963">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neotominae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33972">
+        <obo:IAO_0000118>Streptococcus sp. (group C)</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus sp. group C</obo:IAO_0000118>
+        <obo:IAO_0000118>group C streptococcus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus sp. &apos;group C&apos;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_33988">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rickettsieae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345577">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles paludis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345579">
+        <obo:IAO_0000118>Anopheles (Anopheles) tenebrosus</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles coustani tenebrosus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles tenebrosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345580">
+        <obo:IAO_0000118>Anopheles (Anopheles) ziemanni</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles coustani ziemanni</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles ziemanni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345740">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex fuscocephala</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345741">
+        <obo:IAO_0000118>Aedes malayi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex malayi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345742">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex hutchinsoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345743">
+        <obo:IAO_0000118>Culiciomyia minutissimus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex minutissimus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345924">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pallidothorax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345925">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhinoskusea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_345926">
+        <obo:IAO_0000118>Aedes wardi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus wardi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_346051">
+        <obo:IAO_0000118>Taeniorhynchus whitmorei</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex whitmorei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_346061">
+        <obo:IAO_0000118>Macleaya</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Macleaya &lt;mosquitos&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34607">
+        <obo:IAO_0000118>Acarus cajennensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Cayenne tick</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Amblyomma cajennense</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34609">
+        <obo:IAO_0000118>Gulf Coast tick</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Amblyomma maculatum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34611">
+        <rdfs:label>Rhipicephalus annulatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34613">
+        <rdfs:label>Ixodes ricinus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34615">
+        <rdfs:label>Ixodes persulcatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34619">
+        <obo:IAO_0000118>Anocentor</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dermacentor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34620">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dermacentor andersoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34621">
+        <obo:IAO_0000118>American dog tick</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dermacentor variabilis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34622">
+        <rdfs:label>Haemaphysalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34625">
+        <rdfs:label>Hyalomma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34626">
+        <rdfs:label>Hyalomma dromedarii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34627">
+        <rdfs:label>Hyalomma marginatum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34630">
+        <obo:IAO_0000118>Rhipicephalus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhipicephalus &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34632">
+        <obo:IAO_0000118>Ixodes sanguineus</obo:IAO_0000118>
+        <obo:IAO_0000118>Rhipicephalus rutilus</obo:IAO_0000118>
+        <obo:IAO_0000118>brown dog tick</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhipicephalus sanguineus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34633">
+        <rdfs:label>Rhipicephalus turanicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34690">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles melas</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34691">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles quadriannulatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_34692">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles sundaicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_347913">
+        <rdfs:label>Ixodes trianguliceps</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35336">
+        <obo:IAO_0000118>Human rotavirus 4</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus G4</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype 4</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype G4</obo:IAO_0000118>
+        <obo:IAO_0000118>Human serotype G4 rotavirus</obo:IAO_0000118>
+        <obo:IAO_0000118>Rotavirus serotype G4</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G4</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_354276">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterobacter cloacae complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35500">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pecora</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35565">
+        <rdfs:label xml:lang="en">Ixodes cookei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35732">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Mus tanezumi</obo:IAO_0000118>
+        <obo:IAO_0000118>Oriental house rat</obo:IAO_0000118>
+        <obo:IAO_0000118>Rattus brunneusculus</obo:IAO_0000118>
+        <obo:IAO_0000118>Tanezumi rat</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rattus tanezumi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_35789">
+        <rdfs:label>Rickettsia helvetica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_360405">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles benarrochi B</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36086">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Trichuris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36087">
+        <obo:IAO_0000118>human whipworm</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Trichuris trichiura</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36256">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Motacillidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36330">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>malaria parasite P. ovale</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plasmodium ovale</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_363521">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pluvialis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36420">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>H1N1 swine influenza virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36470">
+        <obo:IAO_0000118>Streptococcus sp. (group A)</obo:IAO_0000118>
+        <obo:IAO_0000118>group A streptococci</obo:IAO_0000118>
+        <obo:IAO_0000118>group A streptococcus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus sp. &apos;group A&apos;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_36809">
+        <obo:IAO_0000118>&quot;Mycobacterium abcessus&quot; Moore and Frerichs 1953</obo:IAO_0000118>
+        <obo:IAO_0000118>&quot;Mycobacterium chelonei&quot; (sic) Bergey et al. 1923</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacterium abscessus</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacterium chelonae subsp. abscessus</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacterium chelonei subsp. abscessus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mycobacteroides abscessus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37020">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>marsh rice rat</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Oryzomys palustris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_37124">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chikungunya virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_371907">
+        <obo:IAO_0000118>Nyctea scandiaca</obo:IAO_0000118>
+        <obo:IAO_0000118>Snowy owl</obo:IAO_0000118>
+        <obo:IAO_0000118>Strix scandiaca</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bubo scandiacus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_373153">
+        <obo:IAO_0000118>Streptococcus pneumoniae str. D39</obo:IAO_0000118>
+        <obo:IAO_0000118>Streptococcus pneumoniae strain D39</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus pneumoniae D39</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_374923">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 1a</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_375138">
+        <obo:IAO_0000118>Culicoides (Avaritia) chiopterus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides chiopterus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_375192">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>unclassified Rotavirus A</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_376584">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles annulipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_376794">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes iyengari</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_376830">
+        <obo:IAO_0000118>Aedes lugubris</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Verrallina lugubris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_376831">
+        <obo:IAO_0000118>Aedes portonovoensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus portonovoensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_379583">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Feliformia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_379584">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Caniformia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_383384">
+        <obo:IAO_0000118>Anopheles (Cellia) rampae</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles cf. maculatus &apos;form K&apos;</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles maculatus group species K</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles sp. &apos;maculatus group K&apos;</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles rampae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_38569">
+        <obo:IAO_0000118>Culex pipiens f. pipiens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pipiens pipiens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_38742">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex restuans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_38743">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex salinarius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_3879">
+        <obo:IAO_0000118>Medicago sativa subsp. sativa</obo:IAO_0000118>
+        <obo:IAO_0000118>alfalfa</obo:IAO_0000118>
+        <obo:IAO_0000118>lucerne</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Medicago sativa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_38937">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Brown anole</obo:IAO_0000118>
+        <obo:IAO_0000118>Norops sagrei</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anolis sagrei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39733">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Astroviridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_39744">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rubulavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_400783">
+        <obo:IAO_0000118>Thraupini</obo:IAO_0000118>
+        <obo:IAO_0000118>tanagers</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Thraupidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40141">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sigmodontinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40323">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Stenotrophomonas</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_40324">
+        <obo:IAO_0000118>Pseudomonas beteli</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas maltiphilia</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas maltophilia</obo:IAO_0000118>
+        <obo:IAO_0000118>Stenotrophomonas africana</obo:IAO_0000118>
+        <obo:IAO_0000118>Xanthomonas maltiphilia</obo:IAO_0000118>
+        <obo:IAO_0000118>Xanthomonas maltophilia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Stenotrophomonas maltophilia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_409345">
+        <obo:IAO_0000118>Anopheles (Cellia) leucosphyrus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles leucosphyrus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_409350">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>dirus species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_412009">
+        <obo:IAO_0000118>Myzomyia longipalpis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles longipalpis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_413496">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cronobacter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41427">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles atroparvus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41428">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles labranchiae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41429">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles maculipennis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41430">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles messeae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41434">
+        <obo:IAO_0000118>Shigella flexneri serotype 1b</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 1b</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418103">
+        <obo:IAO_0000118>Plasmodium</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plasmodium (Plasmodium)</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41819">
+        <obo:IAO_0000118>biting midges</obo:IAO_0000118>
+        <obo:IAO_0000118>no-see-ums</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ceratopogonidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41820">
+        <obo:IAO_0000118>Culicoides</obo:IAO_0000118>
+        <obo:IAO_0000118>punkies</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41821">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides punctatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41827">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_41828">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chironomoidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418994">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhodnius robustus complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418995">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhodnius robustus I</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418996">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhodnius robustus II</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418997">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhodnius robustus III</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_418998">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhodnius robustus IV</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_420550">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex univittatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42068">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pneumocystis jirovecii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_421623">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex mimeticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_422676">
+        <obo:IAO_0000118>Hematozoa Vivier 1982</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aconoidasida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_423054">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eimeriorina</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42409">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>eastern woodrat</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neotoma floridana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42411">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Hesperomys gossypinus</obo:IAO_0000118>
+        <obo:IAO_0000118>cotton mouse</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Peromyscus gossypinus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42415">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Sigmodon hispiedis</obo:IAO_0000118>
+        <obo:IAO_0000118>hispid cotton rat</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sigmodon hispidus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42427">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex erraticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42428">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex erythrothorax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42429">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex nigripalpus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42430">
+        <obo:IAO_0000118>Culex (Melanoconion) pilosus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pilosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42431">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex territans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42432">
+        <obo:IAO_0000118>Culex (Lutzia) tigripes</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex tigripes</obo:IAO_0000118>
+        <obo:IAO_0000118>Lutzia (Metalutzia) tigripes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lutzia tigripes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42433">
+        <obo:IAO_0000118>Culex (Culex) torrentium</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex torrentium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_424717">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 3a</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_424718">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 5a</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_424719">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 6</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_424720">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri Y</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42567">
+        <obo:IAO_0000118>Human rotavirus (serotype G / strain 116E)</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus 9</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus A G9</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus G9</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype 9</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G9</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426437">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhipicephalinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426438">
+        <rdfs:label>Hyalomminae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426439">
+        <rdfs:label>Haemaphysalinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_426455">
+        <rdfs:label>Rhipicephalus &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42839">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles aquasalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42840">
+        <rdfs:label xml:lang="en">Anopheles rangeli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_42897">
+        <obo:IAO_0000118>Shigella flexneri serotype 2a</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 2a</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43061">
+        <rdfs:label xml:lang="en">Anopheles benarrochi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43150">
+        <obo:IAO_0000118>Barn swallow</obo:IAO_0000118>
+        <obo:IAO_0000118>Rauchschwalbe</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Hirundo rustica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43151">
+        <obo:IAO_0000118>American malaria mosquito</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles paulistensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Nyssorhynchus darlingi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles darlingi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43180">
+        <obo:IAO_0000118>Nyssorhynchus konderi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles konderi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43181">
+        <obo:IAO_0000118>Nyssorhynchus oswaldoi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles oswaldoi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43182">
+        <rdfs:label xml:lang="en">Anopheles trinkae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_435321">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 3b</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43786">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicomorpha</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43816">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anophelinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_43817">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44314">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Gracula melanocephala</obo:IAO_0000118>
+        <obo:IAO_0000118>noisy miner</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Manorina melanocephala</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44417">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cyclospora</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44482">
+        <obo:IAO_0000118>Anopheles</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44484">
+        <obo:IAO_0000118>Anopheles</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles &lt;series&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44485">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>maculipennis group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44486">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>maculipennis subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_445">
+        <obo:IAO_0000118>Sarcobium</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Legionella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44517">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>punctipennis group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44531">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>freeborni species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44533">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>maculipennis species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44534">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cellia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44535">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neocellia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44536">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neomyzomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44537">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pyretophorus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44539">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>leucosphyrus subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44541">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>punctulatus species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44542">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>gambiae species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44543">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Nyssorhynchus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44544">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>albimanus section</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44545">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>argyritarsis section</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44548">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>oswaldoi series</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44549">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>oswaldoi group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44550">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>oswaldoi subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_44551">
+        <rdfs:label xml:lang="en">strodei subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_450634">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chilomastix</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_450822">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes ochraceus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_450823">
+        <obo:IAO_0000118>Lasioconops poicilipes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex poicilipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451864">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dikarya</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_451871">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eurotiomycetidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_453036">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles campestris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_45803">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anthus pratensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_45888">
+        <obo:IAO_0000118>Vibrio cholerae serogroup O139</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vibrio cholerae O139</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_46207">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Toxorhynchites</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_46209">
+        <obo:IAO_0000118>Aedes punctor</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus punctor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_464095">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Picornavirales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_46681">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Entamoeba dispar</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_467749">
+        <rdfs:label>Candidatus Neoehrlichia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_468">
+        <obo:IAO_0000118>Acinetobacteraceae</obo:IAO_0000118>
+        <obo:IAO_0000118>Branhamaceae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Moraxellaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_469">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Acinetobacter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_46955">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pseudopunctipennis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_470">
+        <obo:IAO_0000118>Acinetobacter genomosp. 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Acinetobacter genomospecies 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium anitratum</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Acinetobacter baumannii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_471">
+        <obo:IAO_0000118>Acinetobacter genomosp. 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Acinetobacter genomospecies 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus calcoaceticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Moraxella calcoacetica</obo:IAO_0000118>
+        <obo:IAO_0000118>Neisseria winogradskyi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Acinetobacter calcoaceticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_472572">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chilomastix mesnili</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_47466">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Borrelia miyamotoi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_475">
+        <obo:IAO_0000118>Diplobacillus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Moraxella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4751">
+        <obo:IAO_0000118>Mycota</obo:IAO_0000118>
+        <obo:IAO_0000118>fungi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Fungi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4753">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pneumocystis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_478">
+        <obo:IAO_0000118>Bacillus duplex non liquefaciens</obo:IAO_0000118>
+        <obo:IAO_0000118>Moraxella (subgen. Moraxella Lwoff 1939) nonliquefaciens (Scarlett 1916) Bovre 1984</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Moraxella nonliquefaciens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_47886">
+        <obo:IAO_0000118>Chryseomonas luteola</obo:IAO_0000118>
+        <obo:IAO_0000118>Chryseomonas polytricha</obo:IAO_0000118>
+        <obo:IAO_0000118>group Ve-1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pseudomonas luteola</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_480">
+        <obo:IAO_0000118>Branhamella catarrhalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Mikrokkokus catarrhalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Moraxella (subgen. Branhamella Catlin 1970) catarrhalis (Frosch and Kolle 1896) Bovre 1984</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Moraxella catarrhalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_481">
+        <obo:IAO_0000118>Vitreoscillaceae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neisseriaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_481899">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Lichenostomus penicillatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Meliphaga penicillata</obo:IAO_0000118>
+        <obo:IAO_0000118>White-plumed honeyeater</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ptilotula penicillata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_482">
+        <obo:IAO_0000118>&quot;Merismopedia&quot; Zopf 1885</obo:IAO_0000118>
+        <obo:IAO_0000118>Gonococcus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neisseria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_482538">
+        <obo:IAO_0000118>Isospora belli</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cystoisospora belli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_48397">
+        <obo:IAO_0000118>trumperter swan</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cygnus buccinator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_48418">
+        <obo:IAO_0000118>Herpestes auropunctata</obo:IAO_0000118>
+        <obo:IAO_0000118>Herpestes auropunctatus</obo:IAO_0000118>
+        <obo:IAO_0000118>small Indian mongoose</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Urva auropunctata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_487">
+        <obo:IAO_0000118>Diplokokkus intracellularis meningitidis</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus intracellularis</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus meningitidis</obo:IAO_0000118>
+        <obo:IAO_0000118>Micrococcus meningitidis cerebrospinalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Neisseria weichselbaumii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neisseria meningitidis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_487103">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Uranotaenia mashonaensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_48725">
+        <obo:IAO_0000118>Anopheles (Cellia) baimaii</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles dirus D</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles baimaii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_48827">
+        <rdfs:label>Haemaphysalis inermis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_48849">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Fringilla domestica</obo:IAO_0000118>
+        <obo:IAO_0000118>Haussperling</obo:IAO_0000118>
+        <obo:IAO_0000118>House sparrow</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Passer domesticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4890">
+        <obo:IAO_0000118>ascomycete fungi</obo:IAO_0000118>
+        <obo:IAO_0000118>ascomycetes</obo:IAO_0000118>
+        <obo:IAO_0000118>sac fungi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ascomycota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4892">
+        <obo:IAO_0000118>Endomycetales</obo:IAO_0000118>
+        <obo:IAO_0000118>budding yeasts</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Saccharomycetales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_489821">
+        <obo:IAO_0000118>Norovirus genogroup GII.4</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Norovirus GII.4</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_4909">
+        <obo:IAO_0000118>&apos;Candida glycerinogenes&apos;</obo:IAO_0000118>
+        <obo:IAO_0000118>Candida acidothermophilum</obo:IAO_0000118>
+        <obo:IAO_0000118>Candida krusei</obo:IAO_0000118>
+        <obo:IAO_0000118>Issatchenkia orientalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Saccharomyces krusei</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pichia kudriavzevii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49202">
+        <rdfs:label>Dermacentor marginatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49204">
+        <rdfs:label>Haemaphysalis punctata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49205">
+        <rdfs:label>Hyalomma lusitanicum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49206">
+        <rdfs:label>Rhipicephalus pusillus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49916">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>crucians subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49917">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles bradleyi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49918">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles earlei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_49923">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles walkeri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_503348">
+        <obo:IAO_0000118>Aedes (Neomelaniconion) mcintoshi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes mcintoshi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_503354">
+        <obo:IAO_0000118>Aedes (Aedimorphus) cumminsii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes cumminsii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5036">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Histoplasma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5037">
+        <obo:IAO_0000118>Ajellomyces capsulatus (Kwon-Chung) McGinnis &amp; Katz, 1979</obo:IAO_0000118>
+        <obo:IAO_0000118>Cryptococcus capsulatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Emmonsiella capsulata</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Histoplasma capsulatum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_50380">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Lepus palustris</obo:IAO_0000118>
+        <obo:IAO_0000118>marsh rabbit</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sylvilagus palustris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_504471">
+        <rdfs:label>Ixodes ventalloi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_506">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Alcaligenaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5067">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aspergillus parasiticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_507982">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Tyto alba guttata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_508665">
+        <obo:IAO_0000118>Aedes (Finlaya) notoscriptus</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes (Rampamyia) notoscriptus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus notoscriptus</obo:IAO_0000118>
+        <obo:IAO_0000118>Rampamyia notoscriptus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes notoscriptus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_51022">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ancylostoma duodenale</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_51028">
+        <obo:IAO_0000118>human pinworm</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterobius vermicularis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_51030">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Necator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_51031">
+        <obo:IAO_0000118>New World hookworm</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Necator americanus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_516961">
+        <obo:IAO_0000118>Anopheles (Cellia) pseudojamesi</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles ramsayi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles pseudojamesi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_517">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bordetella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_518105">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pipiens complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_520">
+        <obo:IAO_0000118>Bacterium tussis-convulsivae</obo:IAO_0000118>
+        <obo:IAO_0000118>Haemophilus pertussis</obo:IAO_0000118>
+        <obo:IAO_0000118>Hemophilus pertussis</obo:IAO_0000118>
+        <obo:IAO_0000118>Microbe de la coqueluche</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bordetella pertussis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5206">
+        <obo:IAO_0000118>Cryptococcus</obo:IAO_0000118>
+        <obo:IAO_0000118>Filobasidiella</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cryptococcus &lt;basidiomycete fungi&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_523089">
+        <rdfs:label>Haemaphysalis concinna</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_526217">
+        <obo:IAO_0000118>Culex (Culex) coronator</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex coronator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53525">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Deinocerites cancer</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53527">
+        <obo:IAO_0000118>Culex</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53530">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiciomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53531">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eumelanomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53533">
+        <obo:IAO_0000118>Lutzia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lutzia &lt;mosquitos&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53534">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Maillotia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53535">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Melanoconion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53540">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedimorphus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53541">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Stegomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53542">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Finlaya</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53543">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mucidus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53544">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neomelaniconion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53545">
+        <obo:IAO_0000118>Ochlerotatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53549">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sabethini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53550">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53553">
+        <obo:IAO_0000118>Megarhinus rutilus</obo:IAO_0000118>
+        <obo:IAO_0000118>Toxorhinchites rutilus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Toxorhynchites rutilus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_53567">
+        <obo:IAO_0000118>Tripteroides</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Tripteroides &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_54113">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>triannulatus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_543">
+        <obo:IAO_0000118>Enterobacteraceae</obo:IAO_0000118>
+        <obo:IAO_0000118>enterobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>gamma-3 proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterobacteriaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_54388">
+        <obo:IAO_0000118>&quot;Salmonella paratyphi-A&quot; (Brion and Kaiser 1902) Castellani and Chalmers 1919</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium paratyphi</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium paratyphi typhus A</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella choleraesuis choleraesuis (serotype paratyphi A)</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella choleraesuis subsp. choleraesuis serovar Paratyphi A</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella paratyphi</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella paratyphi A</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella paratyphi-a</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Salmonella enterica subsp. enterica serovar Paratyphi A</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_544">
+        <obo:IAO_0000118>Levinea</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Citrobacter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_545656">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex modestus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_546">
+        <obo:IAO_0000118>Bacterium freundii</obo:IAO_0000118>
+        <obo:IAO_0000118>Citrobacter ballerupensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Escherichia freundii</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella ballerup</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella hormaechei</obo:IAO_0000118>
+        <obo:IAO_0000118>the Ballerup group of bacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>the Bethesda group of bacteria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Citrobacter freundii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_547">
+        <obo:IAO_0000118>&quot;Aerobacter&quot; Hormaeche and Edwards 1958</obo:IAO_0000118>
+        <obo:IAO_0000118>Cloaca</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterobacter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5475">
+        <obo:IAO_0000118>Torulopsis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Candida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5476">
+        <obo:IAO_0000118>Candida albicans var. stellatoidea</obo:IAO_0000118>
+        <obo:IAO_0000118>Candida stellatoidea</obo:IAO_0000118>
+        <obo:IAO_0000118>Dematium albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Endomyces albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Monilia albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Monilia stellatoidea</obo:IAO_0000118>
+        <obo:IAO_0000118>Myceloblastanon albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycotorula albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Oidium albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Parasaccharomyces albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Procandida albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Procandida stellatoidea</obo:IAO_0000118>
+        <obo:IAO_0000118>Saccharomyces albicans</obo:IAO_0000118>
+        <obo:IAO_0000118>Syringospora albicans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Candida albicans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_548">
+        <obo:IAO_0000118>Aerobacter aerogenes</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterobacter aerogenes</obo:IAO_0000118>
+        <obo:IAO_0000118>Klebsiella mobilis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Klebsiella aerogenes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_550">
+        <obo:IAO_0000118>Aerobacter cloacae</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus cloacae</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium cloacae</obo:IAO_0000118>
+        <obo:IAO_0000118>Cloaca cloacae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterobacter cloacae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_55418">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Toxostoma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56069">
+        <obo:IAO_0000118>Carbo auritus</obo:IAO_0000118>
+        <obo:IAO_0000118>double-crested cormorant</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phalacrocorax auritus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_561">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Escherichia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_561267">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex theileri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_562">
+        <obo:IAO_0000118>Bacillus coli</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium coli</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium coli commune</obo:IAO_0000118>
+        <obo:IAO_0000118>E. coli</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterococcus coli</obo:IAO_0000118>
+        <obo:IAO_0000118>Escherichia/Shigella coli</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Escherichia coli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56282">
+        <obo:IAO_0000118>Anser sandvicensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Branta sandvicensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_562834">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex nebulosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_563069">
+        <rdfs:label>Hyalomma impeltatum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_566029">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human rotavirus P6</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_56625">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Isospora</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_569587">
+        <obo:IAO_0000118>Mucidus alternans</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus alternans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes alternans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_570">
+        <obo:IAO_0000118>Calymmatobacterium</obo:IAO_0000118>
+        <obo:IAO_0000118>Donovania</obo:IAO_0000118>
+        <obo:IAO_0000118>Hyalococcus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Klebsiella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_57047">
+        <rdfs:label>Dermacentor reticulatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_571">
+        <obo:IAO_0000118>Bacillus oxytocus perniciosus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Klebsiella oxytoca</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5721">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Trichomonas</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5728">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pentatrichomonas hominis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_573">
+        <obo:IAO_0000118>&apos;Klebsiella aerogenes&apos; (Kruse) Taylor et al. 1956</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus pneumoniae</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium pneumoniae crouposae</obo:IAO_0000118>
+        <obo:IAO_0000118>Hyalococcus pneumoniae</obo:IAO_0000118>
+        <obo:IAO_0000118>Klebsiella pneumoniae aerogenes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Klebsiella pneumoniae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5740">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Giardia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_57401">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Centropus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5741">
+        <obo:IAO_0000118>Giardia duodenalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Giardia lamblia</obo:IAO_0000118>
+        <obo:IAO_0000118>Lamblia intestinalis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Giardia intestinalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5758">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Entamoeba</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5759">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Entamoeba histolytica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_576157">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles barbirostris subgroup clade III</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_57706">
+        <obo:IAO_0000118>Citrobacter genomospecies 6</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Citrobacter braakii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_578835">
+        <rdfs:label>Rhipicephalus sanguineus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5794">
+        <obo:IAO_0000118>apicomplexans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Apicomplexa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5799">
+        <obo:IAO_0000118>Eimeriids</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eimeriidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5806">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cryptosporidium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5807">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cryptosporidium parvum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5820">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plasmodium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58210">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Toxostoma rufum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58233">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>albitarsis series</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58234">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>albitarsis group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58236">
+        <obo:IAO_0000118>Nyssorhynchus albitarsis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles albitarsis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58242">
+        <obo:IAO_0000118>Nyssorhynchus braziliensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles braziliensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58243">
+        <obo:IAO_0000118>Nyssorhynchus deaneorum</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles deaneorum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58244">
+        <obo:IAO_0000118>Nyssorhynchus marajoara</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles marajoara</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58245">
+        <rdfs:label xml:lang="en">Anopheles dunhami</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58247">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Laticorn</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58248">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Arribalzagia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58250">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Myzorhynchus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58253">
+        <obo:IAO_0000118>Nyssorhynchus triannulatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles triannulatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58269">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Avaritia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58271">
+        <obo:IAO_0000118>Culicoides</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicoides &lt;subgenus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_583">
+        <obo:IAO_0000118>Liquidobacterium</obo:IAO_0000118>
+        <obo:IAO_0000118>Proteus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Proteus &lt;enterobacteria&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5833">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Plasmodium (Laverania) falciparum</obo:IAO_0000118>
+        <obo:IAO_0000118>malaria parasite P. falciparum</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plasmodium falciparum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_584">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Proteus mirabilis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_585469">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Ardea caledonica</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Nycticorax caledonicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5855">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Haemamoeba vivax</obo:IAO_0000118>
+        <obo:IAO_0000118>Haemamoeba vivax Grassi and Feletti, 1890</obo:IAO_0000118>
+        <obo:IAO_0000118>malaria parasite P. vivax</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plasmodium vivax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5858">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plasmodium malariae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5864">
+        <rdfs:label>Babesia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_586676">
+        <obo:IAO_0000118>Aedes (Finlaya) koreicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Aedes (Hulecoeteomyia) koreicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus koreicus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes koreicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_5868">
+        <obo:IAO_0000118>Theileria microti</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Babesia microti</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_58839">
+        <obo:IAO_0000118>Septata intestinalis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Encephalitozoon intestinalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_590">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Salmonella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_590165">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes mascarensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59123">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>leucosphyrus species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59124">
+        <obo:IAO_0000118>Anopheles (Cellia) balabacensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles balabacensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59127">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>barbirostris group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59128">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>barbirostris subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59130">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>coustani group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59131">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>hyrcanus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59132">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>lesteri subgroup</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59134">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>umbrosus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59136">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles bancroftii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59140">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Myzomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59142">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>funestus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59144">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>minimus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59147">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles flavirostris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59148">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles karwari</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59150">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles kochi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59152">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles longirostris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59160">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles subpictus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59161">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles tessellatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59162">
+        <obo:IAO_0000118>annularis group</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles annularis group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59163">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles annularis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59189">
+        <obo:IAO_0000118>Anopheles farauti 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles farauti No.2</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles hinesorum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59191">
+        <obo:IAO_0000118>Anopheles farauti 4</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles farauti No.4</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles farauti No. 4</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59201">
+        <obo:IAO_0000118>Salmonella cholerae-suis subsp. cholerae-suis</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella choleraesuis subsp. choleraesuis</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica I</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica subsp. I</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica subsp. Subsp. I</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica subsp. Subsp. Ixxx</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Salmonella enterica subsp. enterica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59268">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Larroussius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59269">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Paraphlebotomus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59270">
+        <obo:IAO_0000118>Sergentomyia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sergentomyia &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59271">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sergentomyia minuta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59275">
+        <obo:IAO_0000118>Phlebotomus (Larroussius) perfiliewi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus perfiliewi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_59732">
+        <obo:IAO_0000118>Planobacterium</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chryseobacterium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_60254">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dermacentor occidentalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6032">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Apansporoblastina</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_613">
+        <obo:IAO_0000118>Serratia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Serratia &lt;enterobacteria&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_614">
+        <obo:IAO_0000118>Aerobacter liquefaciens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Serratia liquefaciens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_615">
+        <obo:IAO_0000118>Bacillus marcescens</obo:IAO_0000118>
+        <obo:IAO_0000118>Serratia marcescens subsp. marcescens</obo:IAO_0000118>
+        <obo:IAO_0000118>Serratia marcescens subsp. sakuensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Serratia marcescens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6157">
+        <obo:IAO_0000118>flatworm</obo:IAO_0000118>
+        <obo:IAO_0000118>flatworms</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Platyhelminthes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_61645">
+        <obo:IAO_0000118>CDC Enteric Group 17</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterobacter muelleri</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterobacter asburiae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6181">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Schistosoma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6183">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Schistosoma mansoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6185">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Schistosoma haematobium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_620">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6201">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cyclophyllidea</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6202">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Taenia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_62088">
+        <rdfs:label>Borreliella valaisiana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_621">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella boydii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6214">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Hymenolepididae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6216">
+        <obo:IAO_0000118>rat tapeworm</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Hymenolepis diminuta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_622">
+        <obo:IAO_0000118>Bacillus dysenteriae</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus dysentericus</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus shigae</obo:IAO_0000118>
+        <obo:IAO_0000118>Eberthella dysenteriae</obo:IAO_0000118>
+        <obo:IAO_0000118>Escherichia/Shigella dysenteriae</obo:IAO_0000118>
+        <obo:IAO_0000118>Shigella shigae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella dysenteriae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_623">
+        <obo:IAO_0000118>Escherichia flexneri</obo:IAO_0000118>
+        <obo:IAO_0000118>Escherichia/Shigella flexneri</obo:IAO_0000118>
+        <obo:IAO_0000118>Shigella paradysenteriae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6231">
+        <obo:IAO_0000118>Nemata</obo:IAO_0000118>
+        <obo:IAO_0000118>nematode</obo:IAO_0000118>
+        <obo:IAO_0000118>nematodes</obo:IAO_0000118>
+        <obo:IAO_0000118>roundworm</obo:IAO_0000118>
+        <obo:IAO_0000118>roundworms</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Nematoda</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_62324">
+        <obo:IAO_0000118>African malaria mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles funestus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_62325">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles vaneedeni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6236">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rhabditida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_624">
+        <obo:IAO_0000118>Bacterium sonnei</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella sonnei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6247">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Strongyloides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6248">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Strongyloides stercoralis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6251">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ascaris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6252">
+        <obo:IAO_0000118>common roundworm</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ascaris lumbricoides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6274">
+        <obo:IAO_0000118>Spirurida</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Spirurina</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_629">
+        <obo:IAO_0000118>Yersinia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Yersinia &lt;enterobacteria&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_630">
+        <obo:IAO_0000118>Bacterium enterocoliticum</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Yersinia enterocolitica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63366">
+        <obo:IAO_0000118>Anopheles culicifacies species A</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles culicifacies A</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63367">
+        <obo:IAO_0000118>Anopheles culicifacies species B</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles culicifacies B</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63368">
+        <obo:IAO_0000118>Anopheles culicifacies species C</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles culicifacies C</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_63408">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>culicifacies species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_642">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aeromonas</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_64320">
+        <obo:IAO_0000118>ZIKV</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Zika virus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_644">
+        <obo:IAO_0000118>Aeromonas dourgesi</obo:IAO_0000118>
+        <obo:IAO_0000118>Aeromonas hydrophila (Chester 1901) Stanier 1943 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000118>Aeromonas liquefaciens</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus hydrophilus fuscus</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium hydrophilum</obo:IAO_0000118>
+        <obo:IAO_0000118>Proteus hydrophilus</obo:IAO_0000118>
+        <obo:IAO_0000118>Proteus ichthyosmius</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudomonas hydrophila</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aeromonas hydrophila</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_644619">
+        <obo:IAO_0000118>Aedes camptorhynchus</obo:IAO_0000118>
+        <obo:IAO_0000118>Ochlerotatus (Ochlerotatus) camptorhynchus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus camptorhynchus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_647514">
+        <obo:IAO_0000118>Norovirus genogroup GI.1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Norovirus GI.1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_64895">
+        <obo:IAO_0000118>Borrelia burgdorferi group</obo:IAO_0000118>
+        <obo:IAO_0000118>Borrelia burgdorferi sensu lato</obo:IAO_0000118>
+        <obo:IAO_0000118>Lyme Disease Borrelia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Borreliella</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6526">
+        <obo:IAO_0000118>Australorbis glabratus</obo:IAO_0000118>
+        <obo:IAO_0000118>Planorbis glabratus</obo:IAO_0000118>
+        <obo:IAO_0000118>bloodfluke planorb</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Biomphalaria glabrata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_653292">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia metallica</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_662">
+        <obo:IAO_0000118>Beneckea</obo:IAO_0000118>
+        <obo:IAO_0000118>Listonella</obo:IAO_0000118>
+        <obo:IAO_0000118>Microspira</obo:IAO_0000118>
+        <obo:IAO_0000118>Pacinia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vibrio</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_662894">
+        <obo:IAO_0000118>Aedes flavescens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus flavescens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_663928">
+        <obo:IAO_0000118>Aedes dorsalis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus dorsalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_665339">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orthopodomyia signifera</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6656">
+        <obo:IAO_0000118>arthropods</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Arthropoda</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_666">
+        <obo:IAO_0000118>Bacillo virgola del Koch</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus cholerae</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacillus cholerae-asiaticae</obo:IAO_0000118>
+        <obo:IAO_0000118>Kommabacillus</obo:IAO_0000118>
+        <obo:IAO_0000118>Liquidivibrio cholerae</obo:IAO_0000118>
+        <obo:IAO_0000118>Microspira comma</obo:IAO_0000118>
+        <obo:IAO_0000118>Pacinia cholerae-asiaticae</obo:IAO_0000118>
+        <obo:IAO_0000118>Spirillum cholerae</obo:IAO_0000118>
+        <obo:IAO_0000118>Spirillum cholerae-asiaticae</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio albensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio cholera</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio cholerae biovar albensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio cholerae bv. albensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio cholerae-asiaticae</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio comma</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vibrio cholerae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_667558">
+        <obo:IAO_0000118>Mansonia fuscopennata</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia fuscopennata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_667559">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coquillettidia maculipennis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_667563">
+        <rdfs:label xml:lang="en">Culex cinereus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_667564">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia africana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_667565">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Oculeomyia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_667566">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex annulioris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_670">
+        <obo:IAO_0000118>Beneckea parahaemolytica</obo:IAO_0000118>
+        <obo:IAO_0000118>Oceanomonas parahaemolytica</obo:IAO_0000118>
+        <obo:IAO_0000118>Pasteurella parahaemolytica</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vibrio parahaemolyticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_671232">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus anginosus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_67831">
+        <rdfs:label>Rhipicephalus bursa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_686">
+        <obo:IAO_0000118>&apos;Vibrio eltor&apos;</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio cholerae O1 biovar eltor</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio cholerae biovar El Tor</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio cholerae biovar eltor</obo:IAO_0000118>
+        <obo:IAO_0000118>Vibrio eltor</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vibrio cholerae O1 biovar El Tor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_686388">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes metallicus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_689458">
+        <rdfs:label>Ixodes lividus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_69004">
+        <obo:IAO_0000118>Anopheles farauti sensu stricto</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles farauti</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_690715">
+        <obo:IAO_0000118>Franklin&apos;s gull</obo:IAO_0000118>
+        <obo:IAO_0000118>Larus franklini</obo:IAO_0000118>
+        <obo:IAO_0000118>Larus franklinii</obo:IAO_0000118>
+        <obo:IAO_0000118>Larus pipixcan</obo:IAO_0000118>
+        <obo:IAO_0000118>Leucopheus pipixcan</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Leucophaeus pipixcan</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6935">
+        <rdfs:label>Ixodida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6939">
+        <obo:IAO_0000118>hard ticks</obo:IAO_0000118>
+        <obo:IAO_0000118>hardbacked ticks</obo:IAO_0000118>
+        <obo:IAO_0000118>scale ticks</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ixodidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_693996">
+        <obo:IAO_0000118>Coronavirus</obo:IAO_0000118>
+        <obo:IAO_0000118>Coronavirus group 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Group 1 species</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Alphacoronavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6940">
+        <rdfs:label>Boophilus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_694002">
+        <obo:IAO_0000118>Coronavirus</obo:IAO_0000118>
+        <obo:IAO_0000118>Coronavirus group 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Group 2 species</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Betacoronavirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6942">
+        <obo:IAO_0000118>Aponomma</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Amblyomma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6943">
+        <obo:IAO_0000118>Haemalastor americanus</obo:IAO_0000118>
+        <obo:IAO_0000118>Lone Star tick</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Amblyomma americanum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6944">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ixodes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_6945">
+        <obo:IAO_0000118>Ixodes dammini</obo:IAO_0000118>
+        <obo:IAO_0000118>black-legged tick</obo:IAO_0000118>
+        <obo:IAO_0000118>blacklegged tick</obo:IAO_0000118>
+        <obo:IAO_0000118>deer tick</obo:IAO_0000118>
+        <obo:IAO_0000118>shoulder tick</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ixodes scapularis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_69474">
+        <rdfs:label>Orientia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_69821">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes w-albus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_69822">
+        <obo:IAO_0000118>Culex ethiopicus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex bitaeniorhynchus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_702">
+        <obo:IAO_0000118>C 27 Group</obo:IAO_0000118>
+        <obo:IAO_0000118>Fergusonia</obo:IAO_0000118>
+        <obo:IAO_0000118>Pleisomonas</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plesiomonas</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_703">
+        <obo:IAO_0000118>Aeromonas shigelloides</obo:IAO_0000118>
+        <obo:IAO_0000118>Fergusonia shigelloides</obo:IAO_0000118>
+        <obo:IAO_0000118>Pleisomonas shigelloides</obo:IAO_0000118>
+        <obo:IAO_0000118>Plesiomonas shigelloides corrig. (Bader 1954) Habs and Schubert 1962 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Plesiomonas shigelloides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_70327">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles rivulorum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_704160">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta inornata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_707281">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex declarator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_71031">
+        <obo:IAO_0000118>Human rotavirus G8</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype G8</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G8</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_712">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pasteurellaceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7148">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Nematocera</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7149">
+        <obo:IAO_0000118>nonbiting midges</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chironomidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7157">
+        <obo:IAO_0000118>mosquitos</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culicidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7158">
+        <obo:IAO_0000118>Aedes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_71585">
+        <obo:IAO_0000118>Balantidium coli</obo:IAO_0000118>
+        <obo:IAO_0000118>Neobalantidium coli</obo:IAO_0000118>
+        <obo:IAO_0000118>Paramecium coli</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Balantioides coli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7159">
+        <obo:IAO_0000118>Aedes (Stegomyia) aegypti</obo:IAO_0000118>
+        <obo:IAO_0000118>Stegomyia aegypti</obo:IAO_0000118>
+        <obo:IAO_0000118>yellow fever mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes aegypti</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7160">
+        <obo:IAO_0000118>Asian tiger mosquito</obo:IAO_0000118>
+        <obo:IAO_0000118>Stegomyia albopicta</obo:IAO_0000118>
+        <obo:IAO_0000118>forest day mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes albopictus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7161">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes simpsoni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7162">
+        <obo:IAO_0000118>Aedes triseriatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus triseriatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7163">
+        <obo:IAO_0000118>Culex vexans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes vexans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7164">
+        <obo:IAO_0000118>Anopheles</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7165">
+        <obo:IAO_0000118>African malaria mosquito</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles gambiae S</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles gambiae sensu stricto</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles gambiae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_716545">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>saccharomyceta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7166">
+        <obo:IAO_0000118>common malaria mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles quadrimaculatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7167">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles albimanus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7168">
+        <obo:IAO_0000118>Anopheles (Cellia) dirus</obo:IAO_0000118>
+        <obo:IAO_0000118>Anopheles dirus sensu stricto</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles dirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7170">
+        <obo:IAO_0000118>western malaria mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles freeborni</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7171">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles hermsi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7173">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles arabiensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7174">
+        <obo:IAO_0000118>Culex</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7175">
+        <obo:IAO_0000118>Culex agilis</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex autogenicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex azoriensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex bicolor</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex bifurcatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex calcitrans</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex calloti</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex comitatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex consobrinus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex dipseticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex disjunctus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex doliorum</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex domesticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex erectus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex fasciatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex haematophagus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex longefurcatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex luteus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex marginalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex melanorhinus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex meridionalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex osakaensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex pallipes</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex phytophagus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex quasimodestus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex rufinus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex rufus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex sternopunctatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex thoracicus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex torridus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex trifurcatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex unistriatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex varioannulatus</obo:IAO_0000118>
+        <obo:IAO_0000118>common house mosquito</obo:IAO_0000118>
+        <obo:IAO_0000118>northern house mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex pipiens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7176">
+        <obo:IAO_0000118>Culex fatigans</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex pipiens fatigans</obo:IAO_0000118>
+        <obo:IAO_0000118>Culex pipiens quinquefasciatus</obo:IAO_0000118>
+        <obo:IAO_0000118>southern house mosquito</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex quinquefasciatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7177">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex tarsalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7178">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex tritaeniorhynchus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7182">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7183">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora ferox</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7190">
+        <obo:IAO_0000118>black flies</obo:IAO_0000118>
+        <obo:IAO_0000118>blackflies</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Simuliidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7198">
+        <obo:IAO_0000118>sand flies</obo:IAO_0000118>
+        <obo:IAO_0000118>sandflies</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotominae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7199">
+        <obo:IAO_0000118>Lutzomyia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lutzomyia &lt;genus&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7200">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lutzomyia longipalpis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72132">
+        <obo:IAO_0000118>Human rotavirus 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus G1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype 1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype G1</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus subtype G1</obo:IAO_0000118>
+        <obo:IAO_0000118>Rotavirus serotype G1</obo:IAO_0000118>
+        <obo:IAO_0000118>human serotype G1 rotavirus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_724">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Haemophilus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72408">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles sacharovi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_726">
+        <obo:IAO_0000118>Bacillus X</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Haemophilus haemolyticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_727">
+        <obo:IAO_0000118>Bacterium influenzae</obo:IAO_0000118>
+        <obo:IAO_0000118>Coccobacillus pfeifferi</obo:IAO_0000118>
+        <obo:IAO_0000118>Haemophilus meningitidis</obo:IAO_0000118>
+        <obo:IAO_0000118>Influenza-bacillus</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacterium influenzae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Haemophilus influenzae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72854">
+        <rdfs:label>Hyalomma aegyptium</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72855">
+        <rdfs:label>Hyalomma truncatum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72859">
+        <rdfs:label>Rhipicephalus pulchellus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_72862">
+        <rdfs:label>Hyalomma rufipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_729">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Haemophilus parainfluenzae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_73034">
+        <obo:IAO_0000118>Human rotavirus 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus G2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype 2</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype G2</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_73036">
+        <obo:IAO_0000118>Human rotavirus 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus G3</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype 3</obo:IAO_0000118>
+        <obo:IAO_0000118>Human rotavirus serotype G3</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rotavirus G3</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_732">
+        <obo:IAO_0000118>Haemophilus aphrophilus</obo:IAO_0000118>
+        <obo:IAO_0000118>Haemophilus paraphrophilus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aggregatibacter aphrophilus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_735">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Haemophilus parahaemolyticus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_743691">
+        <obo:IAO_0000118>Aedes fitchii</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus fitchii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_743692">
+        <obo:IAO_0000118>Aedes implicatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus implicatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_743693">
+        <obo:IAO_0000118>Aedes provocans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus provocans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_743694">
+        <obo:IAO_0000118>Aedes riparius</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus riparius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_74868">
+        <obo:IAO_0000118>maculatus group</obo:IAO_0000118>
+        <obo:IAO_0000118>maculatus species complex</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles maculatus group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_74869">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles maculatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_74870">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>nivipes species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_74873">
+        <obo:IAO_0000118>Anopheles (Anopheles) sinensis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles sinensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_753891">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Armigeres kesseli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_75832">
+        <obo:IAO_0000118>American widgeon</obo:IAO_0000118>
+        <obo:IAO_0000118>American wigeon</obo:IAO_0000118>
+        <obo:IAO_0000118>Anas americana</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mareca americana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_766">
+        <obo:IAO_0000118>alpha-1 proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>rickettsias</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rickettsiales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_767021">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus incertae sedis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_767022">
+        <obo:IAO_0000118>Aedes melanimon</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus melanimon</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_767023">
+        <obo:IAO_0000118>Aedes nigromaculis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus nigromaculis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_767024">
+        <obo:IAO_0000118>Aedes squamiger</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus squamiger</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_76717">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Lutra canadensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Northern American river otter</obo:IAO_0000118>
+        <obo:IAO_0000118>river otter</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lontra canadensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_768">
+        <rdfs:label>Anaplasma</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_7742">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Vertebrata</obo:IAO_0000118>
+        <obo:IAO_0000118>vertebrates</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vertebrata</rdfs:label>
+        <rdfs:label>Vertebrata &lt;vertebrates&gt;</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_780">
+        <rdfs:label>Rickettsia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_783">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Rickettsia rickettsii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_784">
+        <obo:IAO_0000118>Rickettsia akamushi</obo:IAO_0000118>
+        <obo:IAO_0000118>Rickettsia orientalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Rickettsia tsutsugamushi</obo:IAO_0000118>
+        <obo:IAO_0000118>Theileria tsutsugamushi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Orientia tsutsugamushi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_78535">
+        <obo:IAO_0000118>&apos;Streptococcus viridans&apos;</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Streptococcus viridans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_80840">
+        <obo:IAO_0000118>Burkholderia/Oxalobacter/Ralstonia group</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Burkholderiales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_810">
+        <obo:IAO_0000118>&quot;Prowazekia&quot; Coles 1953</obo:IAO_0000118>
+        <obo:IAO_0000118>Bedsonia</obo:IAO_0000118>
+        <obo:IAO_0000118>Chlamydophila</obo:IAO_0000118>
+        <obo:IAO_0000118>Miyagawanella</obo:IAO_0000118>
+        <obo:IAO_0000118>Rakeia</obo:IAO_0000118>
+        <obo:IAO_0000118>Rickettsiaformis</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chlamydia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_816">
+        <obo:IAO_0000118>Capsularis</obo:IAO_0000118>
+        <obo:IAO_0000118>Ristella</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacteroides</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_817">
+        <obo:IAO_0000118>Bacillus fragilis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacteroides inaequalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacteroides incommunis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacteroides uncatus</obo:IAO_0000118>
+        <obo:IAO_0000118>Fusiformis fragilis</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudobacterium fragilis</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudobacterium inaequalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudobacterium incommunis</obo:IAO_0000118>
+        <obo:IAO_0000118>Pseudobacterium uncatum</obo:IAO_0000118>
+        <obo:IAO_0000118>Ristella fragilis</obo:IAO_0000118>
+        <obo:IAO_0000118>Ristella incommunis</obo:IAO_0000118>
+        <obo:IAO_0000118>Ristella uncata</obo:IAO_0000118>
+        <obo:IAO_0000118>Sphaerophorus inaequalis</obo:IAO_0000118>
+        <obo:IAO_0000118>Sphaerophorus intermedius</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacteroides fragilis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8342">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Salientia</obo:IAO_0000118>
+        <obo:IAO_0000118>anurans</obo:IAO_0000118>
+        <obo:IAO_0000118>frogs</obo:IAO_0000118>
+        <obo:IAO_0000118>frogs &amp; toads</obo:IAO_0000118>
+        <obo:IAO_0000118>frogs and toads</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anura</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_83558">
+        <obo:IAO_0000118>Chlamydophila pneumoniae</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Chlamydia pneumoniae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8422">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Calamita cinereus</obo:IAO_0000118>
+        <obo:IAO_0000118>Hyla cinerea</obo:IAO_0000118>
+        <obo:IAO_0000118>green tree frog</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dryophytes cinereus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85007">
+        <obo:IAO_0000118>Corynebacteriales</obo:IAO_0000118>
+        <obo:IAO_0000118>Corynebacteriales Goodfellow and Jones 2015</obo:IAO_0000118>
+        <obo:IAO_0000118>Corynebacterineae</obo:IAO_0000118>
+        <obo:IAO_0000118>Mycobacteriales Janke 1924 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mycobacteriales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8511">
+        <obo:IAO_0000118>Lacertilia</obo:IAO_0000118>
+        <obo:IAO_0000118>iguanian lizards</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Iguania</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8517">
+        <obo:IAO_0000118>Common green iguana</obo:IAO_0000118>
+        <obo:IAO_0000118>Lacerta igvana</obo:IAO_0000118>
+        <obo:IAO_0000118>common iguana</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Iguana iguana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_856742">
+        <obo:IAO_0000118>Aedes bancroftianus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus bancroftianus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85698">
+        <obo:IAO_0000118>Achromobacter xilosoxidans</obo:IAO_0000118>
+        <obo:IAO_0000118>Achromobacter xylosoxidans subsp. xylosoxidans</obo:IAO_0000118>
+        <obo:IAO_0000118>Achromobacter xylosoxydans</obo:IAO_0000118>
+        <obo:IAO_0000118>Alcaligenes denitrificans subsp. xylosoxydans</obo:IAO_0000118>
+        <obo:IAO_0000118>Alcaligenes xylosoxidans</obo:IAO_0000118>
+        <obo:IAO_0000118>Alcaligenes xylosoxidans subsp. xylosoxidans</obo:IAO_0000118>
+        <obo:IAO_0000118>Alcaligenes xylosoxydans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Achromobacter xylosoxidans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_857315">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Wyeomyia vanduzeei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_857316">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Wyeomyia mitchellii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85758">
+        <obo:IAO_0000118>Phlebotomus (Larroussius) neglectus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus neglectus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85759">
+        <obo:IAO_0000118>Paraphlebotomus sergenti</obo:IAO_0000118>
+        <obo:IAO_0000118>Phlebotomus (Paraphlebotomus) sergenti</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus sergenti</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_85763">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sergentomyia dentata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_864528">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex neavei</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_866103">
+        <obo:IAO_0000118>Aedes annulipes</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus annulipes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_866105">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culiseta ochroptera</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_869064">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles crucians</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_869066">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Mansonia titillans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_869070">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora columbiae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_869071">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora confinnis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_869072">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora cyanescens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_869073">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psorophora howardii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_869251">
+        <obo:IAO_0000118>Neomelaniconion lineatopenne</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aedes lineatopennis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_87177">
+        <obo:IAO_0000118>Bananaquit</obo:IAO_0000118>
+        <obo:IAO_0000118>Certhia flaveola</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Coereba flaveola</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_871895">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex thriambus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8782">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>avian</obo:IAO_0000118>
+        <obo:IAO_0000118>birds</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Aves</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_87882">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Burkholderia cepacia complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_87883">
+        <obo:IAO_0000118>Burkholderia cepacia genomovar II</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Burkholderia multivorans</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_88112">
+        <obo:IAO_0000118>Eurasian skylark</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Alauda arvensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8825">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Neognathae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8830">
+        <obo:IAO_0000118>waterfowl</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anatidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8852">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Branta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8853">
+        <obo:IAO_0000118>Anas canadensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Anser canadensis</obo:IAO_0000118>
+        <obo:IAO_0000118>Canada goose</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Branta canadensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8867">
+        <obo:IAO_0000118>swans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cygnus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8869">
+        <obo:IAO_0000118>Anas olor</obo:IAO_0000118>
+        <obo:IAO_0000118>mute swan</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cygnus olor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_88916">
+        <rdfs:label>Borreliella spielmanii</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8899">
+        <obo:IAO_0000118>herons</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ardeidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8900">
+        <obo:IAO_0000118>night herons</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Nycticorax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8901">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Ardea nycticorax</obo:IAO_0000118>
+        <obo:IAO_0000118>black-crowned night-heron</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Nycticorax nycticorax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8906">
+        <obo:IAO_0000118>shorebirds and others</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Charadriiformes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8910">
+        <obo:IAO_0000118>gull</obo:IAO_0000118>
+        <obo:IAO_0000118>gulls</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Laridae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8911">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Larus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8912">
+        <obo:IAO_0000118>great black-backed gull</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Larus marinus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8930">
+        <obo:IAO_0000118>pigeons</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Columbidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8931">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Columba</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8932">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Columba domestica</obo:IAO_0000118>
+        <obo:IAO_0000118>Columba livia domestica</obo:IAO_0000118>
+        <obo:IAO_0000118>carrier pigeon</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic pigeon</obo:IAO_0000118>
+        <obo:IAO_0000118>rock dove</obo:IAO_0000118>
+        <obo:IAO_0000118>rock pigeon</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Columba livia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8934">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Columba palumbus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_89586">
+        <rdfs:label>Neoehrlichia mikurensis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_8976">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>landfowls</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Galliformes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9005">
+        <obo:IAO_0000118>turkeys</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phasianidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9018">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Francolinus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9031">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Gallus domesticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Gallus gallus domesticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Phasianus gallus</obo:IAO_0000118>
+        <obo:IAO_0000118>bantam</obo:IAO_0000118>
+        <obo:IAO_0000118>chicken</obo:IAO_0000118>
+        <obo:IAO_0000118>chickens</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Gallus gallus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_90370">
+        <obo:IAO_0000118>Bacillus typhi</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacterium (subgen. Eberthella) typhi</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella choleraesuis serovar Typhi</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella choleraesuis typhi</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica ser. typhi</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica serotype Typhi</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella enterica serovar Typhi</obo:IAO_0000118>
+        <obo:IAO_0000118>Salmonella typhi</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Salmonella enterica subsp. enterica serovar Typhi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_909054">
+        <obo:IAO_0000118>Aedes campestris</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus campestris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_909768">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Acinetobacter calcoaceticus/baumannii complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91061">
+        <obo:IAO_0000118>Bacillus/Lactobacillus/Streptococcus group</obo:IAO_0000118>
+        <obo:IAO_0000118>Firmibacteria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacilli</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_911292">
+        <obo:IAO_0000118>Anopheles (Celia) squamosus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles squamosus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_911293">
+        <obo:IAO_0000118>Culex (Culex) antennatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex antennatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9126">
+        <obo:IAO_0000118>song birds</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Passeriformes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9132">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Australian magpie</obo:IAO_0000118>
+        <obo:IAO_0000118>Cracticus tibicen</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Gymnorhina tibicen</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91347">
+        <obo:IAO_0000118>Enterobacteriaceae and related endosymbionts</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterobacteriaceae group</obo:IAO_0000118>
+        <obo:IAO_0000118>Enterobacteriales</obo:IAO_0000118>
+        <obo:IAO_0000118>gamma-3 proteobacteria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Enterobacterales</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9146">
+        <obo:IAO_0000118>honeyeaters</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Meliphagidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_91561">
+        <obo:IAO_0000118>Cetartiodactyla</obo:IAO_0000118>
+        <obo:IAO_0000118>even-toed ungulates</obo:IAO_0000118>
+        <obo:IAO_0000118>whales, hippos, ruminants, pigs, camels etc.</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Artiodactyla</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9187">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Amsel</obo:IAO_0000118>
+        <obo:IAO_0000118>Eurasian blackbird</obo:IAO_0000118>
+        <obo:IAO_0000118>blackbird</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Turdus merula</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9205">
+        <obo:IAO_0000118>Ibis, herons and pelicans</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Pelecaniformes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9223">
+        <obo:IAO_0000118>parrots and others</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Psittaciformes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9263">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Marsupialia</obo:IAO_0000118>
+        <obo:IAO_0000118>marsupials</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Metatheria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9265">
+        <obo:IAO_0000118>American opossums</obo:IAO_0000118>
+        <obo:IAO_0000118>opossums</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Didelphidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9266">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Didelphis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9336">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>brush-tailed possums</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Trichosurus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9347">
+        <obo:IAO_0000118>Placentalia</obo:IAO_0000118>
+        <obo:IAO_0000118>eutherian mammals</obo:IAO_0000118>
+        <obo:IAO_0000118>placental mammals</obo:IAO_0000118>
+        <obo:IAO_0000118>placentals</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Eutheria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9361">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>nine-banded armadillo</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Dasypus novemcinctus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_93947">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles aconitus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_93948">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anopheles varuna</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_93949">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>minimus species complex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_941442">
+        <obo:IAO_0000118>Giardia duodenalis assemblage A</obo:IAO_0000118>
+        <obo:IAO_0000118>Giardia lamblia (assemblage A)</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Giardia intestinalis assemblage A</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_942">
+        <rdfs:label>Anaplasmataceae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_943">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Ehrlichia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_943103">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Culex perexiguus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_94475">
+        <obo:IAO_0000118>Phlebotomus (Adlerius) simici</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus simici</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_94477">
+        <obo:IAO_0000118>Phlebotomus (Paraphlebotomus) alexandri</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Phlebotomus alexandri</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_94478">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sergentomyia fallax</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9479">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>New World monkeys</obo:IAO_0000118>
+        <obo:IAO_0000118>monkey</obo:IAO_0000118>
+        <obo:IAO_0000118>monkeys</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Platyrrhini</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_948">
+        <obo:IAO_0000118>Anaplasma phagocytophila</obo:IAO_0000118>
+        <obo:IAO_0000118>Cytoecetes bovis</obo:IAO_0000118>
+        <obo:IAO_0000118>Cytoecetes phagocytophila</obo:IAO_0000118>
+        <obo:IAO_0000118>Ehrlichia equi</obo:IAO_0000118>
+        <obo:IAO_0000118>Ehrlichia phagocytophila (Foggie 1949) Philip 1962 (Approved Lists 1980)</obo:IAO_0000118>
+        <obo:IAO_0000118>Ehrlichia sp. &apos;HGE agent&apos;</obo:IAO_0000118>
+        <obo:IAO_0000118>HGE agent</obo:IAO_0000118>
+        <obo:IAO_0000118>Rickettsia phagocytophila ovis</obo:IAO_0000118>
+        <obo:IAO_0000118>agent of human granulocytic ehrlichiosis</obo:IAO_0000118>
+        <obo:IAO_0000118>human granulocytic Ehrlichia</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Anaplasma phagocytophilum</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_95341">
+        <obo:IAO_0000118>Sapporo-like viruses</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sapovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_95486">
+        <obo:IAO_0000118>Burkholderia cepacia genomovar III</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Burkholderia cenocepacia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9606">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>human</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Homo sapiens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9608">
+        <obo:IAO_0000118>dog, coyote, wolf, fox</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Canidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9615">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Canis canis</obo:IAO_0000118>
+        <obo:IAO_0000118>Canis domesticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Canis familiaris</obo:IAO_0000118>
+        <obo:IAO_0000118>dog</obo:IAO_0000118>
+        <obo:IAO_0000118>dogs</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Canis lupus familiaris</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9627">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Canis vulpes</obo:IAO_0000118>
+        <obo:IAO_0000118>red fox</obo:IAO_0000118>
+        <obo:IAO_0000118>silver fox</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Vulpes vulpes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9654">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Ursus lotor</obo:IAO_0000118>
+        <obo:IAO_0000118>northern raccoon</obo:IAO_0000118>
+        <obo:IAO_0000118>raccoon</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Procyon lotor</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9681">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>cat family</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Felidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9685">
+        <obo:IAO_0000118>Felis domesticus</obo:IAO_0000118>
+        <obo:IAO_0000118>Felis silvestris catus</obo:IAO_0000118>
+        <obo:IAO_0000118>cat</obo:IAO_0000118>
+        <obo:IAO_0000118>cats</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic cat</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Felis catus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_976">
+        <obo:IAO_0000118>&quot;Bacteroidota&quot; Whitman et al. 2018</obo:IAO_0000118>
+        <obo:IAO_0000118>BCF group</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacteroides-Cytophaga-Flexibacter group</obo:IAO_0000118>
+        <obo:IAO_0000118>Bacteroidetes</obo:IAO_0000118>
+        <obo:IAO_0000118>CFB group</obo:IAO_0000118>
+        <obo:IAO_0000118>CFB group bacteria</obo:IAO_0000118>
+        <obo:IAO_0000118>Cytophaga-Flexibacter-Bacteroides phylum</obo:IAO_0000118>
+        <obo:IAO_0000118>Sphingobacteria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bacteroidota</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9796">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Equus przewalskii f. caballus</obo:IAO_0000118>
+        <obo:IAO_0000118>Equus przewalskii forma caballus</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic horse</obo:IAO_0000118>
+        <obo:IAO_0000118>equine</obo:IAO_0000118>
+        <obo:IAO_0000118>horse</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Equus caballus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_980429">
+        <obo:IAO_0000118>Aedes infirmatus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ochlerotatus infirmatus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9821">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>boars</obo:IAO_0000118>
+        <obo:IAO_0000118>pigs</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Suidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_984897">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella dysenteriae 1</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_984898">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Shigella flexneri 4a</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9850">
+        <obo:IAO_0000118>deer</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cervidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_985061">
+        <rdfs:label>Ixodes arboricola</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9852">
+        <obo:IAO_0000118>Cervus alces</obo:IAO_0000118>
+        <obo:IAO_0000118>Eurasian elk</obo:IAO_0000118>
+        <obo:IAO_0000118>elk</obo:IAO_0000118>
+        <obo:IAO_0000118>european elk, moose</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Alces alces</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9874">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>white-tailed deer</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Odocoileus virginianus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9881">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Odocoileinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9895">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bovidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_98964">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Loxia cardinalis</obo:IAO_0000118>
+        <obo:IAO_0000118>northern cardinal</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Cardinalis cardinalis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_990147">
+        <obo:IAO_0000118>Poliovirus type 2 Sabin vaccine strain</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Human poliovirus 2 strain Sabin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9913">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Bos bovis</obo:IAO_0000118>
+        <obo:IAO_0000118>Bos primigenius taurus</obo:IAO_0000118>
+        <obo:IAO_0000118>bovine</obo:IAO_0000118>
+        <obo:IAO_0000118>cattle</obo:IAO_0000118>
+        <obo:IAO_0000118>cow</obo:IAO_0000118>
+        <obo:IAO_0000118>dairy cow</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic cattle</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic cow</obo:IAO_0000118>
+        <obo:IAO_0000118>ox</obo:IAO_0000118>
+        <obo:IAO_0000118>oxen</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Bos taurus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9925">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Capra aegagrus hircus</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic goat</obo:IAO_0000118>
+        <obo:IAO_0000118>goat</obo:IAO_0000118>
+        <obo:IAO_0000118>goats</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Capra hircus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9940">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Ovis ammon aries</obo:IAO_0000118>
+        <obo:IAO_0000118>Ovis orientalis aries</obo:IAO_0000118>
+        <obo:IAO_0000118>Ovis ovis</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic sheep</obo:IAO_0000118>
+        <obo:IAO_0000118>lambs</obo:IAO_0000118>
+        <obo:IAO_0000118>sheep</obo:IAO_0000118>
+        <obo:IAO_0000118>wild sheep</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Ovis aries</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9957">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Oryx</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9963">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Caprinae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9979">
+        <obo:IAO_0000118>rabbits and hares</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Leporidae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9983">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>European hare</obo:IAO_0000118>
+        <obo:IAO_0000118>Lepus capensis europaeus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Lepus europaeus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9986">
+        <obo:IAO_0000118>European rabbit</obo:IAO_0000118>
+        <obo:IAO_0000118>Japanese white rabbit</obo:IAO_0000118>
+        <obo:IAO_0000118>Lepus cuniculus</obo:IAO_0000118>
+        <obo:IAO_0000118>domestic rabbit</obo:IAO_0000118>
+        <obo:IAO_0000118>rabbit</obo:IAO_0000118>
+        <obo:IAO_0000118>rabbits</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Oryctolagus cuniculus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9987">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sylvilagus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_99878">
+        <obo:IAO_0000118>Toxostoma cf. curvirostre PS-1</obo:IAO_0000118>
+        <obo:IAO_0000118>Toxostoma curvirostre PS-1</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Toxostoma curvirostre</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9988">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>Lepus sylvaticus floridanus</obo:IAO_0000118>
+        <obo:IAO_0000118>eastern cottontail</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Sylvilagus floridanus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCBITaxon_9989">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000118>rodent</obo:IAO_0000118>
+        <obo:IAO_0000118>rodents</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncbitaxon.owl"/>
+        <rdfs:label>Rodentia</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C122046">
+        <obo:IAO_0000115>Any rod-shaped, Gram-negative, non-spore forming, motile or non-motile bacteria which can ferment lactose with the production of acid and gas.</obo:IAO_0000115>
+        <obo:IAO_0000118>COLIFORM BACTERIA</obo:IAO_0000118>
+        <obo:IAO_0000118>Coliform Bacteria</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+        <rdfs:label>Coliform Bacteria</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C62584">
+        <obo:IAO_0000115>A subtype of Staphylococcus characterized by an inability to produce free plasma coagulase.</obo:IAO_0000115>
+        <obo:IAO_0000118>CNS</obo:IAO_0000118>
+        <obo:IAO_0000118>COAGULASE NEGATIVE STAPHYLOCOCCUS</obo:IAO_0000118>
+        <obo:IAO_0000118>Coagulase-Negative Staphylococcus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+        <rdfs:label>Coagulase-Negative Staphylococcus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C77200">
+        <obo:IAO_0000115>A genus of single-stranded positive sense RNA viruses containing a single RNA molecule. The viral particles are not enveloped and are icosahedral in structure.</obo:IAO_0000115>
+        <obo:IAO_0000118>Rhinovirus</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+        <rdfs:label>Rhinovirus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C86141">
+        <obo:IAO_0000115>A bacterium that is assigned to the genus Streptococcus that is able to reduce the iron content in hemoglobin in red blood cells, thus producing green colored colonies on blood agar plates.</obo:IAO_0000115>
+        <obo:IAO_0000118>Alpha-Hemolytic Streptococcus</obo:IAO_0000118>
+        <obo:IAO_0000118>STREPTOCOCCUS ALPHA-HEMOLYTIC</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+        <rdfs:label>Alpha-Hemolytic Streptococcus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C86190">
+        <obo:IAO_0000115>A bacterium that is assigned to the genus Streptococcus that is able to facilitate the complete rupturing of red blood cells, thus producing wide, clear, zones around colonies on blood agar plates.</obo:IAO_0000115>
+        <obo:IAO_0000118>Beta-Hemolytic Streptococcus</obo:IAO_0000118>
+        <obo:IAO_0000118>STREPTOCOCCUS BETA-HEMOLYTIC</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+        <rdfs:label>Beta-Hemolytic Streptococcus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/NCIT_C86192">
+        <obo:IAO_0000115>A non-taxonomic grouping of beta hemolytic species within the Streptococcus genus that are assigned to the F group.</obo:IAO_0000115>
+        <obo:IAO_0000118>BETA STREPTOCOCCUS, GROUP F</obo:IAO_0000118>
+        <obo:IAO_0000118>Beta Streptococcus Group F</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ncit.owl"/>
+        <rdfs:label>Beta Streptococcus Group F</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000066">
+        <rdfs:label>investigation</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000070">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000107">
+        <obo:IAO_0000111>provides_service_consumer_with</obo:IAO_0000111>
+        <obo:IAO_0000112>The provides_service_consumer_with relation links the service to its primary process it provides for the consumer (as opposed to secondary processual parts of a service process such as payment or documentation).  For example, a &apos;DNA sequencing service&apos; provides_service_consumer_with &apos;DNA sequencing&apos; as the essential process performed by the provider for the client.</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115>A relation between a service and the primary processual part of the service that is performed by the provider for the consumer.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>provides_service_consumer_with</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000124">
+        <obo:IAO_0000111>is_supported_by_data</obo:IAO_0000111>
+        <obo:IAO_0000112>The relation between the conclusion &quot;Gene tpbA is involved in EPS production&quot; and the data items produced using two sets of organisms, one being a tpbA knockout, the other being tpbA wildtype tested in polysacharide production assays and analyzed using an ANOVA.</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115>The relation between a data item and a conclusion where the conclusion is the output of a data interpreting process and the data item is used as an input to that process</obo:IAO_0000115>
+        <obo:IAO_0000117>OBI</obo:IAO_0000117>
+        <obo:IAO_0000119>OBI</obo:IAO_0000119>
+        <obo:IAO_0000119>Philly 2011 workshop</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>is_supported_by_data</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000181">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000220">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>reference subject role</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000272">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">0</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Blood meal assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Pathogen detection assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Species identification assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>protocol</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000293">
+        <obo:IAO_0000111>has_specified_input</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">has_specified_input</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">see is_input_of example_of_usage</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The inverse property of is_specified_input_of</obo:IAO_0000115>
+        <obo:IAO_0000116>8/17/09: specified inputs of one process are not necessarily specified inputs of a larger process that it is part of. This is in contrast to how &apos;has participant&apos; works.</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Larry Hunter</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Melanie Coutot</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">has_specified_input</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000295">
+        <obo:IAO_0000111>is_specified_input_of</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">some Autologous EBV(Epstein-Barr virus)-transformed B-LCL (B lymphocyte cell line) is_input_for instance of Chromum Release Assay described at https://wiki.cbil.upenn.edu/obiwiki/index.php/Chromium_Release_assay</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A relation between a planned process and a continuant participating in that process that is not created during  the process. The presence of the continuant during the process is explicitly specified in the plan specification which the process realizes the concretization of.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON:Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">is_specified_input_of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000299">
+        <obo:IAO_0000111>has_specified_output</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">has_specified_output</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">The inverse property of is_specified_output_of</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Larry Hunter</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">has_specified_output</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000304">
+        <obo:IAO_0000111 xml:lang="en">is_manufactured_by</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">http://www.affymetrix.com/products/arrays/specific/hgu133.affx is_manufactered_by http://www.affymetrix.com/ (if we decide to use these URIs for the actual entities)</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115 xml:lang="en">c is_manufactured_by o means that there was a process p in which c was built in which a person, or set of people or machines did the work(bore the &quot;Manufacturer Role&quot;, and those people/and or machines were members or of directed by the organization to do this.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117 xml:lang="en">Liju Fan</obo:IAO_0000117>
+        <obo:IAO_0000118 xml:lang="en">has_make</obo:IAO_0000118>
+        <obo:IAO_0000118 xml:lang="en">has_manufacturer</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">is_manufactured_by</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000312">
+        <obo:IAO_0000111>is_specified_output_of</obo:IAO_0000111>
+        <obo:IAO_0000111 xml:lang="en">is_specified_output_of</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A relation between a planned process and a continuant participating in that process. The presence of the continuant at the end of the process is explicitly specified in the objective specification which the process realizes the concretization of.</obo:IAO_0000115>
+        <obo:IAO_0000117 xml:lang="en">Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON:Bjoern Peters</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">is_specified_output_of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000415">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>PCR</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000417">
+        <obo:IAO_0000111>achieves_planned_objective</obo:IAO_0000111>
+        <obo:IAO_0000112>A cell sorting process achieves the objective specification &apos;material separation objective&apos;</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>This relation obtains between a planned process and a objective specification when the criteria specified in the objective specification are met at the end of the planned process.</obo:IAO_0000115>
+        <obo:IAO_0000117>BP, AR, PPPB branch</obo:IAO_0000117>
+        <obo:IAO_0000119>PPPB branch derived</obo:IAO_0000119>
+        <obo:IAO_0000232>modified according to email thread from 1/23/09 in accordince with DT and PPPB branch</obo:IAO_0000232>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>achieves_planned_objective</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000435">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Genotyping assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000643">
+        <obo:IAO_0000111>has grain</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>the relation of the cells in the finger of the skin to the finger, in which an indeterminate number of grains are parts of the whole by virtue of being grains in a collective that is part of the whole, and in which removing one granular part does not nec- essarily damage or diminish the whole. Ontological Whether there is a fixed, or nearly fixed number of parts - e.g. fingers of the hand, chambers of the heart, or wheels of a car - such that there can be a notion of a single one being missing, or whether, by contrast, the number of parts is indeterminate - e.g., cells in the skin of the hand, red cells in blood, or rubber molecules in the tread of the tire of the wheel of the car.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">Discussion in Karslruhe with, among others, Alan Rector, Stefan Schulz, Marijke Keet, Melanie Courtot, and Alan Ruttenberg. Definition take from the definition of granular parthood in the cited paper. Needs work to put into standard form</obo:IAO_0000116>
+        <obo:IAO_0000117 xml:lang="en">PERSON: Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000119>PAPER: Granularity, scale and collectivity: When size does and does not matter, Alan Rector, Jeremy Rogers, Thomas Bittner, Journal of Biomedical Informatics 39 (2006) 333-349</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>has grain</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000646">
+        <obo:IAO_0000111>provisions</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115>A relation between an organisation or person and a material entity, where the organization or person provides or supplies the material entity for others to use</obo:IAO_0000115>
+        <obo:IAO_0000116>5/11/2020: A prior definition contained reference to transfer of ownership. (&quot;A relation between an organisation or person and a material entity who owned or has license to the material entity and there was a legal transfer of ownership or licensing of the material entity to the current owner&quot;). This was left out as it was hard to read and it was unclear if/how that transfer restricts the relationship.</obo:IAO_0000116>
+        <obo:IAO_0000117>GROUP: Relations branch</obo:IAO_0000117>
+        <obo:IAO_0000118>supplies</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>provisions</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000647">
+        <obo:IAO_0000111>has_supplier</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A relation between a material entity and an organisation or person who owned or has license to the material entity and there was a legal transfer of ownership or licensing of the material entity to the current owner.</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON: Alan Rutternberg</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Cristian Cocos</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Frank Gibson</obo:IAO_0000117>
+        <obo:IAO_0000117>PERSON: Melanie Courtot</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>has_supplier</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000659">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <obo:clinEpi_label>Sample collection</obo:clinEpi_label>
+        <rdfs:label>Collection</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000661">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>ELISA</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000680">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>whole organism preparation</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000759">
+        <obo:IAO_0000111>Illumina</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000117>Philippe Rocca-Serra</obo:IAO_0000117>
+        <rdfs:label>Illumina</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000833">
+        <obo:IAO_0000111>objective_achieved_by</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115>This relation obtains between an objective specification and a planned process when the criteria specified in the objective specification are met at the end of the planned process.</obo:IAO_0000115>
+        <obo:IAO_0000117>OBI</obo:IAO_0000117>
+        <obo:IAO_0000119>OBI</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>objective_achieved_by</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000846">
+        <obo:IAO_0000111>is member of organization</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>Relating a legal person or organization to an organization in the case where the legal person or organization has a role as member of the organization.</obo:IAO_0000115>
+        <obo:IAO_0000116>2009/10/01 Alan Ruttenberg. Barry prefers generic is-member-of. Question of what the range should be. For now organization. Is organization a population? Would the same relation be used to record members of a population</obo:IAO_0000116>
+        <obo:IAO_0000116>JZ: Discussed on May 7, 2012 OBI dev call. Bjoern points out that we need to allow for organizations to be members of organizations. And agreed by the other OBI developers. So, human and organization were specified in &apos;Domains&apos;. The textual definition was updated based on it.</obo:IAO_0000116>
+        <obo:IAO_0000117>Person:Alan Ruttenberg</obo:IAO_0000117>
+        <obo:IAO_0000117>Person:Helen Parkinson</obo:IAO_0000117>
+        <obo:IAO_0000119>Person:Alan Ruttenberg</obo:IAO_0000119>
+        <obo:IAO_0000119>Person:Helen Parkinson</obo:IAO_0000119>
+        <obo:IAO_0000232>2009/09/28 Alan Ruttenberg. Fucoidan-use-case</obo:IAO_0000232>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>is member of organization</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000852">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>record of missing knowledge</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000858">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>record of unknown sex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000893">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>real time polymerase chain reaction assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000911">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>real time reverse-transcription polymerase chain reaction  assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000951">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">compound treatment design</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0000968">
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>device</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001167">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>day</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000033</obo:EUPATH_0001009>
+        <rdfs:label>age</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001170">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>reverse transcription polymerase chain reaction assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001185">
+        <obo:EUPATH_0001002>Pathogen detection assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>selectively maintained organism</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001221">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">SNP-chip</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001247">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>genotyping by high throughput sequencing assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001274">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>genotyping by array assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001310">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">species design</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001444">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">genotype design</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001464">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">strain or line design</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001479">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>tissue specimen</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001508">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">4</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Either an hour of the day (24 hour clock) or a time range during which the specimen collection was undertaken</obo:IAO_0000115>
+        <obo:clinEpi_label>Study timepoint</obo:clinEpi_label>
+        <rdfs:label>collection time of day</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001617">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001020>yes</obo:EUPATH_0001020>
+        <rdfs:label>PubMed ID</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001619">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">100</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001015>yes</obo:EUPATH_0001015>
+        <obo:IAO_0000115>The raw date range(s) as provided or curated by our team. If the dates are &quot;discontinuous&quot; (see other variable) then this variable will show the exact dates.</obo:IAO_0000115>
+        <obo:clinEpi_label>Sample collection date</obo:clinEpi_label>
+        <rdfs:label>specimen collection date(s) (raw)</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001620">
+        <obo:EUPATH_0000274>1</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>lat</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001003>Latitude</obo:EUPATH_0001003>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>degrees</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000185</obo:EUPATH_0001009>
+        <obo:EUPATH_0001013>variableTree</obo:EUPATH_0001013>
+        <obo:clinEpi_label>Latitude</obo:clinEpi_label>
+        <rdfs:label>Latitude</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001621">
+        <obo:EUPATH_0000274>2</obo:EUPATH_0000274>
+        <obo:EUPATH_0000755>long</obo:EUPATH_0000755>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001003>Longitude</obo:EUPATH_0001003>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>degrees</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000185</obo:EUPATH_0001009>
+        <obo:EUPATH_0001013>variableTree</obo:EUPATH_0001013>
+        <obo:clinEpi_label>Longitude</obo:clinEpi_label>
+        <rdfs:label>Longitude</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001622">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">1</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Study name</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001624">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Species identification assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001627">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:comment>This variable will be auto-populated at load time by looking up GADM polygons.</rdfs:comment>
+        <rdfs:label>country</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001637">
+        <obo:IAO_0000111>has disposition to bind</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115>A relationship between two material entitites that each have disposition to form a complex with the other.</obo:IAO_0000115>
+        <obo:IAO_0000116>This is a shortcut relation, and should expand to say that the two material entities have dispositions, point to the process in which they from a complex that realizes those dispositions, and points to the complex in which the two entities are &apos;bound to&apos; each other</obo:IAO_0000116>
+        <obo:IAO_0000119>IEDB</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>has disposition to bind</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001687">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">4</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Contact</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001688">
+        <obo:IAO_0000111 xml:lang="en">has organization member</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115>Relating an organization to a legal person or organization.</obo:IAO_0000115>
+        <obo:IAO_0000116>See tracker:
+https://sourceforge.net/tracker/index.php?func=detail&amp;aid=3512902&amp;group_id=177891&amp;atid=886178</obo:IAO_0000116>
+        <obo:IAO_0000117>Person: Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">has organization member</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001883">
+        <obo:IAO_0000111 xml:lang="en">Bioinformatics Resource Center contact person</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A person who is the contact representative of a Bioinformatics Resource Center</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON: Chris Stoeckert, Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <obo:OBI_0001886>Bioinformatics Resource Center Contact Name</obo:OBI_0001886>
+        <dc:source>NIAID GSCID-BRC</dc:source>
+        <rdfs:label xml:lang="en">Bioinformatics Resource Center contact person</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001888">
+        <obo:IAO_0000111 xml:lang="en">sequencing facility contact person</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A person who is the contact representative at the sequencing facility</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON: Chris Stoeckert, Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <obo:OBI_0001886>Sequencing Facility Contact Name</obo:OBI_0001886>
+        <dc:source>NIAID GSCID-BRC</dc:source>
+        <rdfs:label xml:lang="en">sequencing facility contact person</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001889">
+        <obo:IAO_0000111 xml:lang="en">specimen provider principal investigator</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A person who is a principal investigator and provides the specimen</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON: Chris Stoeckert, Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <obo:OBI_0001886>Sample Provider Principal Investigator (PI) Name</obo:OBI_0001886>
+        <dc:source>NIAID GSCID-BRC</dc:source>
+        <rdfs:label xml:lang="en">specimen provider principal investigator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001895">
+        <obo:IAO_0000111 xml:lang="en">specimen collector</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A person who collects the specimen</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON: Chris Stoeckert, Jie Zheng</obo:IAO_0000117>
+        <obo:IAO_0000119>NIAID GSCID-BRC metadata working group</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <obo:OBI_0001886>Specimen Collector Name</obo:OBI_0001886>
+        <dc:source>NIAID GSCID-BRC</dc:source>
+        <rdfs:label xml:lang="en">specimen collector</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001898">
+        <obo:EUPATH_0001002>Blood meal assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Organism identification assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Pathogen detection assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>comment</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001909">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001012>yes</obo:EUPATH_0001012>
+        <obo:IAO_0000115>Single species/taxon assignment based on potentially multiple species identification assays performed on the same specimen. E.g. different PCR tests to identify cryptic species complex members.</obo:IAO_0000115>
+        <obo:POPBIO_8000181>EUPATH_0000609.POPBIO_8000017</obo:POPBIO_8000181>
+        <obo:POPBIO_8000183>yes</obo:POPBIO_8000183>
+        <rdfs:label>species</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001927">
+        <obo:IAO_0000111>specifies value of</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115>A relation between a value specification and an entity which the specification is about.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>specifies value of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001937">
+        <obo:IAO_0000111>has specified numeric value</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A relation between a value specification and a number that quantifies it.</obo:IAO_0000115>
+        <obo:IAO_0000116>A range of &apos;real&apos; might be better than &apos;float&apos;. For now we follow &apos;has measurement value&apos; until we can consider technical issues with SPARQL queries and reasoning.</obo:IAO_0000116>
+        <obo:IAO_0000117>PERSON: James A. Overton</obo:IAO_0000117>
+        <obo:IAO_0000119>OBI</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>has specified numeric value</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001938">
+        <obo:IAO_0000111>has value specification</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A relation between an information content entity and a value specification that specifies its value.</obo:IAO_0000115>
+        <obo:IAO_0000117>PERSON: James A. Overton</obo:IAO_0000117>
+        <obo:IAO_0000119>OBI</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label>has value specification</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0001960">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>taxonomic diversity assessment by targeted gene survey</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002001">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Illumina HiSeq 2000</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002110">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">3</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>DOI</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002135">
+        <obo:IAO_0000111 xml:lang="en">has specified value</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000123"/>
+        <obo:IAO_0000115>A relation between a value specification and a literal.</obo:IAO_0000115>
+        <obo:IAO_0000116>This is not an RDF/OWL object property. It is intended to link a value found in e.g. a database column of &apos;M&apos; (the literal) to an instance of a value specification class, which can then be linked to indicate that this is about the biological gender of a human subject.</obo:IAO_0000116>
+        <obo:IAO_0000119>OBI</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">has specified value</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002441">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>physical examination of individual</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002647">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Giemsa staining</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002648">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>individual organism specimen</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002687">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>ligase detection reaction</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002695">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Insecticide resistance assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002699">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by detecting alpha esterase activity assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002700">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by detecting beta esterase activity assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002701">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by detecting acetylcholinesterase activity assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002702">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by detecting glutathione S-transferase activity assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002703">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by detecting carboxylic ester hydrolase activity assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002704">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by detecting mixed-function oxidase assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002705">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>direct insecticide resistance bioassay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002706">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>topical application insecticide resistance bioassay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002707">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>direct insecticide resistance diagnostic assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002708">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance dose response assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002709">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance time response assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002710">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Centre for Disease Control and Prevention bottle bioassay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002711">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>WHO cone kit diagnostic assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002712">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>WHO paper kit diagnostic assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002713">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>WHO larvicide diagnostic assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002714">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance dose response by bottle assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002715">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance dose response by survival of larvae assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002716">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance dose response by WHO paper kit assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002718">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance time response by WHO paper kit assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002719">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by amplification refractory mutation system assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002720">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by primer introduced restriction analysis PCR assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002721">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by nested polymerase chain reaction assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002723">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">ligase detection reaction-fluorescent microsphere assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002725">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by fluorogenic PCR assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002726">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by PCR-RELP assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002727">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>insecticide resistance by short interspersed elements PCR assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002728">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Pathogen detection assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002729">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>VectorTest assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002730">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>pathogen detection by Rapid Analyte Measurement Platform assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002731">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>pathogen detection by loop-mediated isothermal amplification assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002732">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>Blood meal assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002733">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">counter current immunoelectrophoresis</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002734">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">DNA based blood meal finger printing</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002735">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">by size</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002736">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>organism identification by cross mating assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002737">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>organism identification by cytological chromosome examination assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002738">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>organism identification by isoenzyme electrophoresis assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002739">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>organism identification by morphological examination assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002740">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>organism identification by PCR assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002741">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>organism identification by specific DNA hybridization assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002742">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>organism identification by salinity tolerance assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002901">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>visible light source</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002903">
+        <obo:IAO_0000111>BioGents</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>An organization that manufactures mosquito traps and other mosquito control products.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>WEB:https://eu.biogents.com/about-biogents/</obo:IAO_0000119>
+        <rdfs:label>BioGents</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002904">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>adult arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002905">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>animal-biting arthropod specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002906">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>animal-biting outdoor arthropod specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002907">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>aquatic arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002908">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod resting in animal house specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002909">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod resting outdoors on artificial support specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002910">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod resting outdoors on natural support specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002911">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod resting outdoors specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002912">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002913">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">field population catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002914">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>human-biting arthropod specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002915">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>human-biting indoor arthropod specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002916">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>human-biting outdoor arthropod specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002917">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>knockdown arthropod specimen collection by pyrethrum spray</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002918">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>knockdown arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002919">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>live arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002920">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002921">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>artificial pit shelter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002922">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>baited net trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002923">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>barrier trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002924">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">BG-Counter trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002925">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>BG-Sentinel trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002926">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Centers for Disease Control and Prevention light trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002927">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>dipper for arthropod immatures</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002928">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>encephalitis virus surveillance trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002929">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>gravid trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002930">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>light trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002931">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>light trap for indoor use</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002932">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>light trap for outdoor use</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002933">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">mosquito magnet pro</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002934">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>MosquiTRAP</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002935">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>New Jersey light trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002936">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">OVI light-suction trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002937">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>outlet window trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002938">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>ovitrap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002940">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>resting box trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002941">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>resting bucket</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002942">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Shannon trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002943">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>sticky resting bucket</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002944">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>sticky trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002945">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">population based design</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002983">
+        <obo:EUPATH_0001002>Collection site</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Altitude</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002988">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">3</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Duration of specimen collection in days</obo:IAO_0000115>
+        <rdfs:label>duration of specimen collection</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002992">
+        <obo:EUPATH_0001002>Pathogen detection assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>prevalence of pathogen in specimens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002993">
+        <obo:EUPATH_0001002>Blood meal assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Phenotype assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label>blood meal host prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002994">
+        <obo:EUPATH_0001002>Blood meal assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>blood meal host presence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002995">
+        <obo:EUPATH_0001002>Blood meal assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>blood meal host organism</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002998">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod collection process with automated identification</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0002999">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>gravid female arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003000">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Resting flight-capable arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003002">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>arthropod resting in human house specimen collection by aspiration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003003">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>landing arthropod specimen collection process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003004">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>flying adult arthropod collection process by passive interception</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003006">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">collection of larvae from well nets</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003007">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">trap containing small non-human animal bait</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003008">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">trap for emerging adult arthropods</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003029">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>barcode target locus</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003030">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>oligonucleotide primer set</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003032">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>genotyping by PCR assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003086">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>laboratory-based population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003454">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">mosquito magnet liberty plus catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003495">
+        <obo:IAO_0000111>Abbott</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A manufacturer of rapid point-of-care assay devices.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000119>WEB:https://www.globalpointofcare.abbott/en/about.html</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/obi-ontology/obi/issues/1456</obo:IAO_0000233>
+        <rdfs:label>Abbott</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003496">
+        <obo:IAO_0000111>J. Mitra</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A manufacturer of in vitro diagnostic assay kits in India.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000119>WEB:https://jmitra.co.in/about-us/</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/obi-ontology/obi/issues/1456</obo:IAO_0000233>
+        <rdfs:label>J. Mitra</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0003497">
+        <obo:IAO_0000111>InBios</obo:IAO_0000111>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000120"/>
+        <obo:IAO_0000115>A manufacturer that specializes in in vitro diagnostic devices designed to test for infectious diseases.</obo:IAO_0000115>
+        <obo:IAO_0000117>John Judkins ORCID:0000-0001-6595-0902</obo:IAO_0000117>
+        <obo:IAO_0000119>WEB:https://inbios.com/about/</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/obi-ontology/obi/issues/1456</obo:IAO_0000233>
+        <rdfs:label>InBios</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0100026">
+        <obo:IAO_0000111 xml:lang="en">organism</obo:IAO_0000111>
+        <obo:IAO_0000112 xml:lang="en">animal</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">fungus</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">plant</obo:IAO_0000112>
+        <obo:IAO_0000112 xml:lang="en">virus</obo:IAO_0000112>
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <obo:IAO_0000115 xml:lang="en">A material entity that is an individual living system, such as animal, plant, bacteria or virus, that is capable of replicating or reproducing, growth and maintenance in the right environment. An organism may be unicellular or made up, like humans, of many billions of cells divided into specialized tissues and organs.</obo:IAO_0000115>
+        <obo:IAO_0000116>10/21/09: This is a placeholder term, that should ideally be imported from the NCBI taxonomy, but the high level hierarchy there does not suit our needs (includes plasmids and &apos;other organisms&apos;)</obo:IAO_0000116>
+        <obo:IAO_0000116>13-02-2009:
+OBI doesn&apos;t take position as to  when an organism starts or ends being an organism - e.g. sperm, foetus.
+This issue is outside the scope of OBI.</obo:IAO_0000116>
+        <obo:IAO_0000117>GROUP: OBI Biomaterial Branch</obo:IAO_0000117>
+        <obo:IAO_0000119 xml:lang="en">WEB: http://en.wikipedia.org/wiki/Organism</obo:IAO_0000119>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/obi.owl"/>
+        <rdfs:label xml:lang="en">organism</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0300311">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">observation design</rdfs:label>
+        <rdfs:label xml:lang="en">observational design</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0302716">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>pool of specimens</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0400065">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>light source</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0500000">
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:comment>Children will be values present in the i_investigation.txt sheet of popbio ISA-Tabs in the &quot;STUDY DESIGN DESCRIPTORS&quot; section. These are not currently loaded as EDA entity data. However, they fail validation if the loader doesn&apos;t know about the terms, so they go here so that it does.
+
+Note: this ISA-Tab section also includes terms that used to be in the now-deprecated custom &quot;STUDY TAGS&quot; section. For example, tags/terms like &quot;ICEMR&quot;.</rdfs:comment>
+        <rdfs:label>Design and Tag values</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0600018">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>material portioning</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OBI_0600047">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>sequencing assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OMO_0001000">
+        <obo:IAO_0000115 xml:lang="en">The term was added to the ontology on the assumption it was in scope, but it turned out later that it was not.</obo:IAO_0000115>
+        <obo:IAO_0000116 xml:lang="en">This obsolesence reason should be used conservatively. Typical valid examples are: un-necessary grouping classes in disease ontologies, a phenotype term added on the assumption it was a disease.</obo:IAO_0000116>
+        <obo:IAO_0000117 rdf:resource="http://orcid.org/0000-0001-5208-3432"/>
+        <obo:IAO_0000233>https://github.com/information-artifact-ontology/ontology-metadata/issues/77</obo:IAO_0000233>
+        <obo:IAO_0000234>https://orcid.org/0000-0001-5208-3432</obo:IAO_0000234>
+        <rdfs:label>out of scope</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/OPL_0000267">
+        <obo:IAO_0000115>A Plasmodium that is located either in the bloodstream of the vertebrate host or midgut of mosquito vector during gametocyte stage. Gametocytes are the precursor cells of the macro- or microgametes</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/opl.owl"/>
+        <rdfs:label>Plasmodium gametocyte</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000033">
+        <obo:EUPATH_0001002>Insecticide resistance assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>microgram per liter</obo:EUPATH_0001008>
+        <obo:EUPATH_0001008>milligram per square meter</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/EFO_0004373</obo:EUPATH_0001009>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000301</obo:EUPATH_0001009>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:comment>This is only found in VBP0000115 and is flagged for remediation in redmine</rdfs:comment>
+        <rdfs:label>concentration</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000047">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:POPBIO_8000181>EUPATH_0000609.POPBIO_8000017</obo:POPBIO_8000181>
+        <obo:POPBIO_8000183>yes</obo:POPBIO_8000183>
+        <obo:clinEpi_label>Sex</obo:clinEpi_label>
+        <rdfs:label>biological sex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000122">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>length</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000146">
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>degree Celsius</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000027</obo:EUPATH_0001009>
+        <rdfs:label>temperature</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000383">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>female</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000384">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>male</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000462">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>absent</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0000467">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>present</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001152">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>susceptible toward</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001178">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>resistant to</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0001338">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>mixed sex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0002368">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>nulliparous</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PATO_0040028">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>parous</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PCO_0000029">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>multi-species collection of organisms</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/PCO_0000054">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>count unit</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000189</obo:EUPATH_0001009>
+        <rdfs:label>number of generations of selection</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_5600153">
+        <rdfs:label xml:lang="en">Haemaphisalis sulcata</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_5600156">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:comment>Locations of arthropod collection given a shorthand name which is named population</rdfs:comment>
+        <rdfs:label xml:lang="en">Pre-defined population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_5600157">
+        <rdfs:label xml:lang="en">St. Joseph County</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000001">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>tick engorgement status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000002">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:comment>Where the collection is from a human or animal host, e.g. for ticks</rdfs:comment>
+        <rdfs:label>Host</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000003">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>host sex</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000004">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>host age if human</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000005">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>host body part</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000006">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>personal protection</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000007">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label>tick pathogen presence/absence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000008">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Borrelia burgdorferi infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000009">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Anaplasma phagocytophilum infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000010">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia microti infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000011">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borrelia miyamotoi infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000012">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Ehrlichia spp. infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000013">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Francisella tularensis infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000014">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Rickettsia rickettsii infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000015">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">5</obo:EUPATH_0000274>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>town</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000016">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>property type</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000017">
+        <obo:IAO_0000115>The number of specimens collected during routine, unbiased surveillance.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">unbiased specimen count</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000018">
+        <obo:IAO_0000115>The number of specimens used in an assay that provides quantitative results. For example the percentage of infected specimens.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">number of input specimens to quantitative assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000019">
+        <obo:IAO_0000115>The number of specimens used in an assay that provides qualitative results. For example 50 mosquitoes could be mashed up and assayed for pathogen detection by PCR and the result is &apos;present&apos; or &apos;absent&apos; and there is no indication of how many of the input specimens were postiive.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">number of input specimens to qualitative assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000020">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">malaria pathogen presence/absence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000021">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium falciparum infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000022">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium vivax infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000023">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium malariae infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000024">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium ovale infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000025">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">malaria pathogen prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000026">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium falciparum prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000027">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium vivax prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000028">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium malariae prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000029">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium ovale prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000030">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">arbovirus presence/absence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000031">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Eastern equine encephalomyelitis virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000032">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Western equine encephalomyelitis virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000033">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">St. Louis encephalitis virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000034">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">West Nile virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000035">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">La Crosse virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000036">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">arbovirus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000037">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Eastern equine encephalomyelitis virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000038">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Western equine encephalomyelitis virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000039">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">St. Louis encephalitis virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000040">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">West Nile virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000041">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">La Crosse virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000042">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Zika virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000043">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Zika virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000044">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Heartland virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000045">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">tick pathogen prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000046">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Heartland virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000047">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">INSDC accession</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000048">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella valaisiana infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000049">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">barcode sequence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000050">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella valaisiana prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000051">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">NCBI Popset accession</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000052">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">barcode sequence length</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000053">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">BOLD accession</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000054">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia divergens infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000055">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia divergens prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000056">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000057">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000058">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella lusitaniae infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000059">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Anaplasma phagocytophilum prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000060">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Anaplasma infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000061">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Anaplasma prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000062">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Powassan virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000063">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Powassan virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000064">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Annotation values</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000065">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F0 larvae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000066">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">partially-fed</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000067">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">adult laboratory population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000068">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F2 adults</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000069">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">blood-fed</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000070">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F2 larvae</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000071">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella lusitaniae prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000072">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F0 adults emerged from field collected eggs</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000073">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F0 eggs</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000074">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F1 larvae bred from field collected mosquitoes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000075">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">larval laboratory population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000076">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borrelia miyamotoi prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000077">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F1 adults from field collected mosquitoes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000078">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">vector organism</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000079">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">status of population endemicity</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000080">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F1 adults emerged from field collected eggs</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000081">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">half gravid</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000082">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">F1 larvae emerged from field collected eggs</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000083">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">fully-fed</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000084">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">AChE1 loci</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000085">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Targeted genotyping</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000086">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">AChE1 locus G119</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000087">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr loci</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000088">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus D1763</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000089">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus F1534</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000090">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus I1011</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000091">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus I1532</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000092">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus L1014</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000093">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus N1575</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000094">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus S989</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000095">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus V1016</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000096">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Gste2 loci</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000097">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Gste2 locus L119</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000098">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Rdl loci</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000099">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Rdl locus A296</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000100">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Chromosomal inversions</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000101">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">AChE1 locus G280</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000102">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of wild type AChE1 G280</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000103">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of AChE1 G280S</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000104">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Gste2 locus I114</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000105">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of wild type Gste2 I114</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000106">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Cyp4j5 loci</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000107">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Cyp4j5 locus L43</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000108">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of wild type Cyp4j5 L43</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000109">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Kdr locus L995</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000110">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of Kdr L995F</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000111">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of Kdr L995S</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000112">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001008>percent</obo:EUPATH_0001008>
+        <obo:EUPATH_0001009>http://purl.obolibrary.org/obo/UO_0000187</obo:EUPATH_0001009>
+        <rdfs:label xml:lang="en">prevalence of wild type Kdr L995</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000113">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:comment>hopefully not needed - adding for to OWL just in case this would break the export/import from Chado</rdfs:comment>
+        <rdfs:label xml:lang="en">sodium channel structural change</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000114">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">unknown blood meal host</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000115">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">live chicken bait</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000116">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Highlands J virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000117">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Highlands J virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000118">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">dengue virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000119">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">dengue virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000120">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">COI</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000121">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">ND4</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000122">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Bacillus thurigiensis toxin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000123">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Bacillus thurigiensis var. israelensis toxin</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000124">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">chikungunya virus infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000125">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">chikungunya virus prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000126">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">cow and goat</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000127">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">cow and pig</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000128">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Spotted fever group infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000129">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Spotted fever group prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000130">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borrelia afzelii infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000131">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">yeast</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000132">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>A geolocation precision objective specification of five decimal places.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/126</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">geolocation precision objective of five decimal places</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000133">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000115>A geolocation precision objective specification of six decimal places.</obo:IAO_0000115>
+        <obo:IAO_0000117>Person: John Judkins</obo:IAO_0000117>
+        <obo:IAO_0000119>VEuPathDB</obo:IAO_0000119>
+        <obo:IAO_0000233>https://github.com/VEuPathDB-ontology/VEuPathDB-ontology/issues/126</obo:IAO_0000233>
+        <rdfs:label xml:lang="en">geolocation precision objective of six decimal places</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000134">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">heat</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000135">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borrelia afzelii prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000136">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">ITS2</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000137">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">reported population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000138">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Rickettsia helvetica infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000139">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Rickettsia helvetica prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000140">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">organic infusion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000141">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000142">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Plasmodium prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000143">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Uranotaenia syntheta complex</rdfs:label>
+        <rdfs:label xml:lang="en">cow and human</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000144">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Neoehrlichia mikurensis infection status</rdfs:label>
+        <rdfs:label xml:lang="en">Uranotaenia syntheta</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000145">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Neoehrlichia mikurensis prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000146">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">established population</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000147">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">reference enzyme activity</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000148">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">reference for biochemical assay</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000149">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">reference sample</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000150">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">DNA barcoding</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000151">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Anaplasma phagocytophilum str. Ap-v1 infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000152">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Anaplasma phagocytophilum str. Ap-v1 prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000153">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella burgdorferi prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000154">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella mayonii infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000155">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella mayonii prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000156">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia venatorum infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000157">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia venatorum prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000158">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia microti prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000159">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella garinii infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000160">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella garinii prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000161">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Anaplasma phagocytophilum str. Ap-ha infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000162">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Anaplasma phagocytophilum str. Ap-ha prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000163">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000164">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Babesia prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000165">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borrelia infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000166">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borrelia prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000167">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella spielmanii infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000168">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Borreliella spielmanii prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000169">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">equivocal</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000170">
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:comment>Use this in addition to PubMedID and/or DOI if you wish to preserve the originally provided free-text citation, such as &quot;Al-Khafaji AM, Bell-Sakyi L, Fracasso G, Luu L, Heylen D, et al. Isolation of Candidatus Rickettsia vini from Belgian Ixodes arboricola ticks and propagation in tick cell lines. Ticks Tick Borne Dis. 2020;11:101511.&quot;</rdfs:comment>
+        <rdfs:label xml:lang="en">free text citation</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000171">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Crohn&apos;s disease</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000172">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Rickettsia spp. infection status</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000173">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Rickettsia spp. prevalence</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000174">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">surveillance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000175">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">undisclosed pathogen detection method</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000176">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">human baited double net trap - outdoors</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000177">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">swarm net catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000178">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">CDC miniature light trap model 512</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000179">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:EUPATH_0001013>everywhere</obo:EUPATH_0001013>
+        <rdfs:comment>Takes values 0, 1 or 2
+0: only the country variable will be auto-populated by geo-lookup
+1: only country and admin level1
+2: all three, country, admin1 and admin2 will be populated</rdfs:comment>
+        <rdfs:label xml:lang="en">max_admin_level</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000180">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">human baited double net trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000182">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">citizen science collection</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000184">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">animal biting catch - indoors</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000185">
+        <obo:EUPATH_0000274 rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">5</obo:EUPATH_0000274>
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Institution</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000186">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">concentration of assayed insecticide</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000187">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">dose response</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000188">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">LC50</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000189">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">LC90</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000190">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">flagging catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000191">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">LC95</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000192">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">undisclosed pathogen detection protocol</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000193">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">LC99 and LC100</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000194">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">terrain environment catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000195">
+        <rdfs:label xml:lang="en">time response</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000196">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">diagnostic test</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000197">
+        <rdfs:label xml:lang="en">assay result</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000198">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">resting clay pot trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000199">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">C02 tick trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000200">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">human baited light trap catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000201">
+        <rdfs:label xml:lang="en">biochemical activity</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000202">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">passive surveillance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000203">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">human baited double net trap - indoors</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000204">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">cow-baited tent collection</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000205">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">blanket dragging catch</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000206">
+        <rdfs:label>Put unused terms here just in case they were not unused (don&apos;t want to break the loader)</rdfs:label>
+        <rdfs:label xml:lang="en">Trash can</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000207">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">insecticide resistance/susceptibility</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000208">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Processes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000209">
+        <obo:EUPATH_0001005>category</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">specimen collection date and time</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000210">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">live animal bait</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000211">
+        <rdfs:label xml:lang="en">Culex pipiens morphological group</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000212">
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>If multiple named traps are used, the name of the trap used will be recorded here. Not guaranteed to be unique across datasets. For reference mainly.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">trap ID</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000213">
+        <obo:EUPATH_0001002>Collection</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Detailed non-geographical information about where the sample was collected.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">Source habitat</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000214">
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Tags</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/POPBIO_8000215">
+        <obo:EUPATH_0001002>Study</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:IAO_0000115>Unique ID for a component dataset/study in VectorBase&apos;s population biology (PopBio) resource. The IDs are formatted VBPnnnnnnn where nnnnnnn is a zero-padded integer.</obo:IAO_0000115>
+        <rdfs:label xml:lang="en">PopBio Study ID</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000052">
+        <obo:IAO_0000115 xml:lang="en">a relation between a specifically dependent continuant (the characteristic) and any other entity (the bearer), in which the characteristic depends on the bearer for its existence.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">characteristic of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000053">
+        <obo:IAO_0000115 xml:lang="en">Inverse of characteristic_of</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has characteristic</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000056">
+        <obo:IAO_0000115 xml:lang="en">a relation between a continuant and a process, in which the continuant is somehow involved in the process</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">participates in</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000057">
+        <obo:IAO_0000115 xml:lang="en">a relation between a process and a continuant, in which the continuant is somehow involved in the process</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has participant</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000058">
+        <obo:IAO_0000115 xml:lang="en">A relationship between a generically dependent continuant and a specifically dependent continuant, in which the generically dependent continuant depends on some independent continuant in virtue of the fact that the specifically dependent continuant also depends on that same independent continuant. A generically dependent continuant may be concretized as multiple specifically dependent continuants.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">is concretized as</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000059">
+        <obo:IAO_0000115 xml:lang="en">A relationship between a specifically dependent continuant and a generically dependent continuant, in which the generically dependent continuant depends on some independent continuant in virtue of the fact that the specifically dependent continuant also depends on that same independent continuant. Multiple specifically dependent continuants can concretize the same generically dependent continuant.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">concretizes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000079">
+        <obo:IAO_0000115 xml:lang="en">a relation between a function and an independent continuant (the bearer), in which the function specifically depends on the bearer for its existence</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">function of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000080">
+        <obo:IAO_0000115>A relation between a quality and an independent continuant (the bearer), in which the quality specifically depends on the bearer for its existence.</obo:IAO_0000115>
+        <rdfs:label>quality of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000081">
+        <obo:IAO_0000115 xml:lang="en">a relation between a role and an independent continuant (the bearer), in which the role specifically depends on the bearer for its existence</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">role of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000085">
+        <obo:IAO_0000115 xml:lang="en">a relation between an independent continuant (the bearer) and a function, in which the function specifically depends on the bearer for its existence</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has function</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000086">
+        <obo:IAO_0000115 xml:lang="en">a relation between an independent continuant (the bearer) and a quality, in which the quality specifically depends on the bearer for its existence</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has quality</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0000087">
+        <obo:IAO_0000115 xml:lang="en">a relation between an independent continuant (the bearer) and a role, in which the role specifically depends on the bearer for its existence</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has role</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001000">
+        <obo:IAO_0000115 xml:lang="en">a relation between two distinct material entities, the new entity and the old entity, in which the new entity begins to exist when the old entity ceases to exist, and the new entity inherits the significant portion of the matter of the old entity</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">derives from</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001001">
+        <obo:IAO_0000115 xml:lang="en">a relation between two distinct material entities, the old entity and the new entity, in which the new entity begins to exist when the old entity ceases to exist, and the new entity inherits the significant portion of the matter of the old entity</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">derives into</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001015">
+        <obo:IAO_0000115 xml:lang="en">a relation between two independent continuants, the location and the target, in which the target is entirely within the location</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">location of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0001025">
+        <obo:IAO_0000115 xml:lang="en">a relation between two independent continuants, the target and the location, in which the target is entirely within the location</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">located in</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002081">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">before or simultaneous with</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002083">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">before</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002087">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">immediately preceded by</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002091">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">starts during</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002092">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">happens during</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002093">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">ends during</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002131">
+        <obo:IAO_0000115>x overlaps y if and only if there exists some z such that x has part z and z part of y</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">overlaps</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002180">
+        <obo:IAO_0000115>w &apos;has component&apos; p if w &apos;has part&apos; p and w is such that it can be directly disassembled into into n parts p, p2, p3, ..., pn, where these parts are of similar type.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has component</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002215">
+        <obo:IAO_0000115>A relation between a material entity (such as a cell) and a process, in which the material entity has the ability to carry out the process. </obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">capable of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002216">
+        <obo:IAO_0000115>c stands in this relationship to p if and only if there exists some p&apos; such that c is capable_of p&apos;, and p&apos; is part_of p.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">capable of part of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002222">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">temporally related to</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002223">
+        <obo:IAO_0000115>inverse of starts with</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">starts</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002229">
+        <obo:IAO_0000115>inverse of ends with</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">ends</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002248">
+        <obo:IAO_0000115>A relationship that holds between a substance and a chemical entity, if the chemical entity is part of the substance, and the chemical entity forms the biologically active component of the substance.</obo:IAO_0000115>
+        <obo:IAO_0000118>has active pharmaceutical ingredient</obo:IAO_0000118>
+        <obo:IAO_0000118>has active substance</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>has active ingredient</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002249">
+        <obo:IAO_0000115>inverse of has active ingredient</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>active ingredient in</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002314">
+        <obo:IAO_0000115>q characteristic of part of w if and only if there exists some p such that q inheres in p and p part of w.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">characteristic of part of</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002323">
+        <obo:IAO_0000115>A mereological relationship or a topological relationship</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">mereotopologically related to</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002328">
+        <obo:IAO_0000115>A grouping relationship for any relationship directly involving a function, or that holds because of a function of one of the related entities.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">functionally related to</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002351">
+        <obo:IAO_0000115>has member is a mereological relation between a collection and an item.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">has member</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002410">
+        <obo:IAO_0000115>relation that links two events, processes, states, or objects such that one event, process, state, or object (a cause) contributes to the production of another event, process, state, or object (an effect) where the cause is partly or wholly responsible for the effect, and the effect is partly or wholly dependent on the cause.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label xml:lang="en">causally related to</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002418">
+        <obo:IAO_0000115>p is &apos;causally upstream or within&apos; q iff p is causally related to q, and the end of p precedes, or is coincident with, the end of q.</obo:IAO_0000115>
+        <obo:IAO_0000118>affects</obo:IAO_0000118>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>causally upstream of or within</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002500">
+        <obo:IAO_0000115>A relationship between a material entity and a process where the material entity has some causal role that influences the process</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>causal agent in process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002501">
+        <obo:IAO_0000115>p is causally related to q if and only if p or any part of p and q or any part of q are linked by a chain of events where each event pair is one where the execution of p influences the execution of q. p may be upstream, downstream, part of, or a container of q.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>causal relation between processes</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002502">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>depends on</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002595">
+        <obo:IAO_0000115>A relationship that holds between a material entity and a process in which causality is involved, with either the material entity or some part of the material entity exerting some influence over the process, or the process influencing some aspect of the material entity.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>causal relation between material entity and a process</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/RO_0002606">
+        <obo:IAO_0000115>c is a substance that treats d if c is a material entity (such as a small molecule or compound) and d is a pathological process, phenotype or disease, and c is capable of some activity that negative regulates or decreases the magnitude of d.</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/ro.owl"/>
+        <rdfs:label>is substance that treats</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>Microsatellite repeat length polymorphisms</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_201AAT1">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite 201AAT1 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_88AT1">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite 88AT1 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_A1">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite A1 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_A10">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite A10 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_A9">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite A9 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AC1">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AC1 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AC2">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AC2 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AC4">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AC4 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AC5">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AC5 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AC7">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AC7 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADA03">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADA03 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADA20">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADA20 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADA32">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADA32 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADA40">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADA40 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADA41">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADA41 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADC02">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADC02 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADC107RIB">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADC107RIB lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADC110">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADC110 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADC137">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADC137 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADC138">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADC138 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADC28">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADC28 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADMP9">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADMP9 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_ADSP2">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite ADSP2 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG1">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG1 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H125">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H125 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H135">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H135 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H164">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H164 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H175">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H175 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H197">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H197 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H57">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H57 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H675">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H675 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG2H85">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG2H85 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H119">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H119 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H127">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H127 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H242">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H242 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H249">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H249 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H311">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H311 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H312">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H312 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H555">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H555 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H577">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H577 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H59">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H59 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H746">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H746 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H811">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H811 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H812">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H812 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H817">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H817 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG3H93">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG3H93 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG4">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG4 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG5">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG5 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AG7">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AG7 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AGXH100">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AGXH100 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AGXH25">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AGXH25 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AGXH36">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AGXH36 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AGXH71">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AGXH71 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_AT1">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite AT1 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_B07">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite B07 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_B2">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite B2 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_B3">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite B3 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_CT2">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite CT2 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_F06">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite F06 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_H08">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite H08 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_M201">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite M201 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_M313">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite M313 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ1">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ1 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ10">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ10 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ11">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ11 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ13">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ13 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ16">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ16 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ19">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ19 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ2">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ2 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ20">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ20 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ21">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ21 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ22">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ22 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ23">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ23 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ24">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ24 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ25">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ25 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ26">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ26 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ28">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ28 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ29">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ29 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ3">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ3 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ31">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ31 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ33">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ33 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ34">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ34 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ36">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ36 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ37">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ37 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ39">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ39 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ4">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ4 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ41">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ41 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ42">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ42 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ45">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ45 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ5">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ5 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ8">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ8 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000289_MCQ9">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>microsatellite MCQ9 lengths</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000703">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>experimental_result_region</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0000704">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>gene</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0001027">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">genotype</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0001505">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>reference_genome</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0001507">
+        <obo:EUPATH_0001002>Genotyping assay</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>variant_collection</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0001763">
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">variant_frequency</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/SO_0001769">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label>group1.variant_phenotype</rdfs:label>
+        <rdfs:label>variant_phenotype</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/STATO_0000101">
+        <obo:IAO_0000115 xml:lang="en">the relationship between a fraction and the number above the line</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/stato.owl"/>
+        <rdfs:label>has numerator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/STATO_0000259">
+        <obo:IAO_0000115 xml:lang="en">the relationship between a fraction and the number below the line (or divisor)</obo:IAO_0000115>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/stato.owl"/>
+        <rdfs:label>has denominator</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000069">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>larval stage</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000070">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">pupa</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0000105">
+        <obo:EUPATH_0001002>Sample</obo:EUPATH_0001002>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <obo:POPBIO_8000181>EUPATH_0000609.POPBIO_8000017</obo:POPBIO_8000181>
+        <obo:POPBIO_8000183>yes</obo:POPBIO_8000183>
+        <rdfs:label>life cycle stage</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0004730">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>instar larval stage</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0009097">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>gravid organism</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0014405">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">nymph</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UBERON_0018241">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>prime adult stage</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000023">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A mass unit which is equal to one millionth of a gram or 10^[-6] g.&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>microgram</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000024">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A mass unit which is equal to one thousandth of one millionth of a gram or 10^[-9] g.&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>nanogram</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000027">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A temperature unit which is equal to one kelvin degree. However, they have their zeros at different points. The centigrade scale has its zero at 273.15 K.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>degree Celsius</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000031">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A time unit which is equal to 60 seconds.&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>minute</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000032">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A time unit which is equal to 3600 seconds or 60 minutes.&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>hour</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000033">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A time unit which is equal to 24 hours.&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>day</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000036">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A time unit which is equal to 12 months which in science is taken to be equal to 365.25 days.&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>year</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000169">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dimensionless concentration notation which denotes the amount of a given substance in a total amount of 1,000,000 regardless of the units of measure used as long as they are the same or 1 part in 10^[6].&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>parts per million</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000170">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dimensionless concentration notation which denotes the amount of a given substance in a total amount of 1,000,000,000 regardless of the units of measure as long as they are the same or 1 part in 10^[9].&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>parts per billion</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000188">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dimensionless unit which denoted an irrational real number, approximately equal to 3.14159 which is the ratio of a circle&apos;s circumference to its diameter in Euclidean geometry.&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>pi</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000190">
+        <rdfs:label>ratio</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000192">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dimensionless count unit which denotes the number of molecules.&quot; [MGED:MGED]</rdfs:comment>
+        <rdfs:label>molecule count</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000193">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dimensionless percent unit which denotes the homogeneity of a biomaterial.&quot; [MGED:MGED]</rdfs:comment>
+        <rdfs:label>purity percentage</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000194">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dimensionless percent unit which denotes the density of an attached or monolayer culture (e.g., cell culture).&quot; [MGED:MGED]</rdfs:comment>
+        <rdfs:label>confluence percentage</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000195">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A temperature unit which is equal to 5/9ths of a kelvin. Negative 40 degrees Fahrenheit is equal to negative 40 degrees Celsius.&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>degree Fahrenheit</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000196">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dimensionless concentration notation which denotes the acidity of a solution in terms of activity of hydrogen ions (H+).&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>pH</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000197">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A specific volume unit which is equal to one liter volume occupied by one kilogram of a particular substance.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>liter per kilogram</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000198">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A specific volume unit which is equal to a thousandth of a liter per kilogram or 10^[-3] l/kg.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>milliliter per kilogram</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000199">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A specific volume unit which is equal to one millionth of a liter per kilogram or 10^[-6] l/kg.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>microliter per kilogram</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000201">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A unit of cell concentration which is equal to one cell in a volume of 1 milliliter.&quot; [Bioedonline:Bioedonline]</rdfs:comment>
+        <rdfs:label>cells per milliliter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000203">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A catalytic (activity) concentration unit which is equal to 1 katal activity of a catalyst in a given volume of one cubic meter.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>katal per cubic meter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000204">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A catalytic (activity) concentration unit which is equal to 1 katal activity of a catalyst in a given volume of one thousandth of a cubic meter.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>katal per liter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000206">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A volume per unit volume unit which is equal to one millionth of a liter of solute in one cubic meter of solution.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>milliliter per cubic meter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000207">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A volume per unit volume unit which is equal to one millionth of a liter of solute in one liter of solution.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>milliliter per liter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000208">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A mass density unit which is equal to mass of an object in grams divided by the volume in deciliters.&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>gram per deciliter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000273">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A mass unit density which is equal to mass of an object in milligrams divided by the volume in liters.&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>milligram per liter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000274">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A mass unit density which is equal to mass of an object in micrograms divided by the volume in millliters.&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>microgram per milliliter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000301">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A mass unit density which is equal to mass of an object in micrograms divided by the volume in liters.&quot; [UOC:GVG]</rdfs:comment>
+        <rdfs:label>microgram per liter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0000309">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A dose unit which is equal to 1 milligram of a toxic or pharmaceutical substance per square meter of surface area of the recipient subject.&quot; [UO:PC]</rdfs:comment>
+        <rdfs:label>milligram per square meter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0010025">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;An area unit which is equivalent to 1 furlong x 1 chain. This is equal to an area of 4,046.856,4224 square meters, or 43,500 square feet.&quot; [Wikipedia:Wikipedia]</rdfs:comment>
+        <rdfs:label>acre</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0010049">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;An area density unit which is equal to the mass of an object in grams divided by the surface area in meters squared.&quot; [NIST:NIST]</rdfs:comment>
+        <rdfs:label>gram per square meter</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/UO_0010053">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/uo.owl"/>
+        <rdfs:comment>&quot;A unit of mass concentration defined as the number of micrograms of a substance per 250 ml Wheaton bottle.&quot; [UOB:LTS]</rdfs:comment>
+        <rdfs:label>micrograms per wheaton bottle</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0000233">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>unpublished</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0000667">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>website</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001047">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>data deposited</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001080">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>ICEMR</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001085">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>abundance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001090">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>whole genome sequencing</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001092">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Orange County Florida Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001093">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>South Walton County Florida Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001094">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Iowa State Mosquito Surveillance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001096">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Manatee County Florida Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001097">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Hernando County Florida Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001098">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Collier Mosquito Control District</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001100">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>CC BY-NC</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001101">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Biogents Mosquito Surveillance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001103">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Southern Nevada Health District</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001104">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Marion County Public Health Department, Indiana</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001105">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Anastasia Mosquito Control District, Florida</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001109">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>microsatellites</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001115">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>The Worldwide Insecticide resistance Network</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001117">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Salt Lake City Mosquito Abatement District</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001118">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Cass County Vector Control District</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001119">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Toledo Area Sanitary District</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001120">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Northwest Mosquito and Vector Control District</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001121">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Ada County Weed, Pest, and Mosquito Abatement</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001123">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>viral surveillance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001125">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Entomology Group, Pirbright</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001128">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Rhode Island Department of Environmental Management</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001131">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>City of Suffolk Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001132">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Lee County Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001133">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>DesPlaines Valley Mosquito Abatement</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001134">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Maryland Department of Agriculture</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001135">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Montana State Mosquito Surveillance</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001137">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Franklin County Public Health</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001138">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Tarrant County Public Health Department</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001142">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>North Dakota Department of Health</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001153">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Commonwealth Scientific and Industrial Research Organisation</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001160">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Powell lab and collaborators</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001161">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Florida Keys Mosquito Control District</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001163">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Illinois Natural History Survey</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001164">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Norfolk County Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001166">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">curated by IRMapper</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VBcv_0001167">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">Volusia County Mosquito Control</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VO_0000741">
+        <obo:IAO_0000412 rdf:resource="http://purl.obolibrary.org/obo/vo.owl"/>
+        <rdfs:label>Haemophilus influenzae serotype b</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VSMO_0001302">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>Fay-Prince trap</rdfs:label>
+    </rdf:Description>
+    <rdf:Description rdf:about="http://purl.obolibrary.org/obo/VSMO_0001446">
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
+        <rdfs:label>collection of the adult flying stage of insects</rdfs:label>
+    </rdf:Description>
+</rdf:RDF>
+
+
+
+<!-- Generated by the OWL API (version 4.5.25.2023-02-15T19:15:49Z) https://github.com/owlcs/owlapi -->
+

--- a/Load/ontology/popbio/field_trials.owl
+++ b/Load/ontology/popbio/field_trials.owl
@@ -1309,7 +1309,7 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000001"/>
         <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
-        <rdfs:label xml:lang="en">linker spatial bin</rdfs:label>
+        <rdfs:label xml:lang="en">geo-spatial region</rdfs:label>
     </owl:Class>
     
 
@@ -1317,9 +1317,9 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     <!-- http://purl.obolibrary.org/obo/FIELD_0000009 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000009">
-        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000001"/>
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000011"/>
         <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
-        <rdfs:label xml:lang="en">linker time period</rdfs:label>
+        <rdfs:label xml:lang="en">date period (YYYY or YYYY-MM)</rdfs:label>
     </owl:Class>
     
 
@@ -1346,6 +1346,106 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000010"/>
         <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
         <rdfs:label xml:lang="en">spatio-temporal binning</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000013 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000013">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">T0 household ID</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000014 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000014">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000011"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">date (YYYY-MM-DD)</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000015 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000015">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">nearest health facility</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000016 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000016">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">trap type</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000017 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000017">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">trap location</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000018 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000018">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">number of family members</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000019 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000019">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">bednet usage</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000020 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000020">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">house type</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000021 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000021">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">wall surface</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000022 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000022">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000002"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">eaves</rdfs:label>
     </owl:Class>
     
 

--- a/Load/ontology/popbio/field_trials.owl
+++ b/Load/ontology/popbio/field_trials.owl
@@ -1450,6 +1450,56 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
     
 
 
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000023 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000023">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000003"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">morphological species ID</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000024 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000024">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000003"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">abdominal status</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000025 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000025">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000003"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">molecular species ID (PCR)</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000026 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000026">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000003"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">CSP ELISA result</rdfs:label>
+    </owl:Class>
+    
+
+
+    <!-- http://purl.obolibrary.org/obo/FIELD_0000027 -->
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000027">
+        <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000003"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
+        <rdfs:label xml:lang="en">blood meal host assay result</rdfs:label>
+    </owl:Class>
+    
+
+
     <!-- http://purl.obolibrary.org/obo/OBI_0001620 -->
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/OBI_0001620">

--- a/Load/ontology/popbio/field_trials.owl
+++ b/Load/ontology/popbio/field_trials.owl
@@ -1308,6 +1308,7 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000008">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000001"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
         <rdfs:label xml:lang="en">linker spatial bin</rdfs:label>
     </owl:Class>
     
@@ -1317,6 +1318,7 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000009">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000001"/>
+        <obo:EUPATH_0001005>variable</obo:EUPATH_0001005>
         <rdfs:label xml:lang="en">linker time period</rdfs:label>
     </owl:Class>
     
@@ -1342,6 +1344,7 @@ https://sourceforge.net/tracker/?func=detail&amp;aid=3603413&amp;group_id=177891
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FIELD_0000012">
         <rdfs:subClassOf rdf:resource="http://purl.obolibrary.org/obo/FIELD_0000010"/>
+        <obo:EUPATH_0001005>value</obo:EUPATH_0001005>
         <rdfs:label xml:lang="en">spatio-temporal binning</rdfs:label>
     </owl:Class>
     


### PR DESCRIPTION
This will be the OWL file that drives the transmission zero test load but also future field trial surveillance datasets (which will be loaded as separate datasets, but can share the OWL file hopefully)