### PR TITLE
add mass spec as a collection for mbio

### DIFF
--- a/Load/ontology/General/collections/collections.yaml
+++ b/Load/ontology/General/collections/collections.yaml
@@ -155,3 +155,11 @@ label: normalized number of taxon-specific sequence matches
 isProportion: false
 isCompositional: false
 normalizationMethod: CPM
+---
+stable_id: OBI_0000470
+member: molecule
+memberPlural: molecules
+label: mass spectrometry assay
+isProportion: true
+isCompositional: true
+normalizationMethod: sumToUnity


### PR DESCRIPTION
In the FARMM study, the variables under the mass spectrometry assay entity all form a collection. We want to add this collection as a real "collection" so that we can use it in the apps.