### PR TITLE
Add protection for missing lobs in popbio species reconciliation script

### DIFF
--- a/Load/bin/reconcilePopBioSpecies.pl
+++ b/Load/bin/reconcilePopBioSpecies.pl
@@ -151,6 +151,7 @@ my %sample2species; # sample_id => species_name => count
 
 while (my ($sample_id, $sample_name, $sample_atts_loc, $assay_id, $assay_name, $assay_atts_loc) = $sample_and_organism_id_assays_stmt->fetchrow_array()) {
 
+  
   $sample2atts_json{$sample_id} //= readLob($sample_atts_loc, $dbh);
   $sample2sample_name{$sample_id} = $sample_name;
 
@@ -243,6 +244,10 @@ $dbh->commit;
 #
 sub readLob {
   my ($lobLocator, $dbh, $chunkSize) = @_;
+
+  # Return an empty JSON object string if the LOB locator is undefined
+  return '{}' unless defined $lobLocator;
+
   my $offset = 1;   # Offsets start at 1, not 0
   $chunkSize //= 65536;
   my $output;

--- a/Load/bin/reconcilePopBioSpecies.pl
+++ b/Load/bin/reconcilePopBioSpecies.pl
@@ -151,7 +151,6 @@ my %sample2species; # sample_id => species_name => count
 
 while (my ($sample_id, $sample_name, $sample_atts_loc, $assay_id, $assay_name, $assay_atts_loc) = $sample_and_organism_id_assays_stmt->fetchrow_array()) {
 
-  
   $sample2atts_json{$sample_id} //= readLob($sample_atts_loc, $dbh);
   $sample2sample_name{$sample_id} = $sample_name;
 


### PR DESCRIPTION
We had a dataset that had no species results and was causing this problem

```
reconcilePopBioSpecies.pl   --extDbRlsSpec "ISATab_VBP0000855_RSRC|2024-04-11" --veupathOntologySpec "OntologyTerm_popbio_taxonomy_RSRC|dontcare"

DBD::Oracle::db::ora_lob_read: locator is not of type OCILobLocatorPtr at /home/jaycolin/workspace/vec/gus_home/bin/reconcilePopBioSpecies.pl line 251.
```

I am assuming that the `$lobLocator` returned from the database was NULL/undefined.

With this PR in place, the erroneous dataset above should instead fail with the following message:

```
  FATAL ERROR: No species reconciliation result and no --fallbackSpecies option provided
```

This can then be solved on the data curation side (either by figuring out why many rows in the original data have no species values, or by providing a "fallback" species on the commandline (or in the dataset XML).