### PR TITLE
if there is a vdi_id env variable set, use it for study_stable_id

### DIFF
--- a/Load/plugin/perl/InsertEntityGraph.pm
+++ b/Load/plugin/perl/InsertEntityGraph.pm
@@ -391,6 +391,14 @@ sub createGusStudy {
   my $description = $study->getDescription();
   my $studyInternalAbbrev = $cleanedIdentifier;
   $studyInternalAbbrev =~ s/[-\.\s]/_/g; #clean name/id for use in oracle table name
+
+  # TODO:  This is a temporary solution for VDI Datasets.
+  # TODO:  because we can have multiple studies, the study_stable_id or study internal abbrev should be set in the investigation.xml
+  my $vdiId = $ENV{VDI_ID};
+  if($vdiId) {
+    $cleanedIdentifier = $vdiId;
+  }
+
   return $self->getGusModelClass('Study')->new({stable_id => $cleanedIdentifier, external_database_release_id => $extDbRlsId, internal_abbrev => $studyInternalAbbrev});
 }
 sub ifNeededUpdateStudyMaxAttrLength {

--- a/Load/plugin/perl/InsertEntityGraph.pm
+++ b/Load/plugin/perl/InsertEntityGraph.pm
@@ -393,7 +393,7 @@ sub createGusStudy {
   $studyInternalAbbrev =~ s/[-\.\s]/_/g; #clean name/id for use in oracle table name
 
   # TODO:  This is a temporary solution for VDI Datasets.
-  # TODO:  because we can have multiple studies, the study_stable_id or study internal abbrev should be set in the investigation.xml
+  # TODO:  because an investigation can have multiple studies, the study_stable_id or study internal abbrev should be set in the investigation.xml
   my $vdiId = $ENV{VDI_ID};
   if($vdiId) {
     $cleanedIdentifier = $vdiId;


### PR DESCRIPTION
The study names are defined either in ISATab files or ISASimple (investigation.xml).  There can be many studies for an investigation. For now we can override the study_stable_id to the VDI_ID ENVIRONMENT variable if it is set.  

Long term we need to update how the ISASimple files are made and parsed to ISA objects.   The abbreviation and stable_id can be set there