### PR TITLE
Rnaseq percentile bugfix

### DIFF
--- a/Load/lib/perl/RnaSeqAnalysisEbi.pm
+++ b/Load/lib/perl/RnaSeqAnalysisEbi.pm
@@ -111,6 +111,7 @@ sub makeProfiles {
 
     # cleanup for non unique
     if(!$isUnique) {
+      $valueType = "nonunique.$valueType";
       $makePercentiles = 0;
     }
 
@@ -128,6 +129,8 @@ sub makeProfiles {
 	     samples => $samples,
 	     profileSetName => $profileSetName,
          sampleNameAsDir => 1,
+         isUnique => $isUnique,
+         strand => $strand,
 	    });
 
     my $header = 0;

--- a/Load/lib/perl/RnaSeqCounts.pm
+++ b/Load/lib/perl/RnaSeqCounts.pm
@@ -250,11 +250,11 @@ sub munge {
     $self->SUPER::munge();
     
     unlink($tpmFile);
+
     if ($isUnique) {
+        # can only unlink if we made it above
         unlink($countFile);
-    }
-    
-    if ($isUnique) {
+        # only want to create for unique profiles
         $self->createEDACountsFile();
     }
     


### PR DESCRIPTION
This started as a fix for the loading issue Bindu reported where percentile values were not being loaded. This was not an issue with the plugin, it was happening because the munger was not writing percentile values into the profile files. I ended up fixing a couple of other issues I found along the way:

1. Reverted the change introduced to RnaSeqAnalysisEbi.pm by John's commit 2e1a9d4 - this was causing the bug where percentile values were not written into profile files. I did not revert changes to any other files from this commit.
2. Noticed we were creating edaCounts files for both unique and non-unique profiles, and the second was overwriting the first. In EDA context, we only care about unique counts - changed the script so that we do not create an EDA file for nonunique counts.
3. Similarly, in stranded datasets, we were creating EDA files for both first and second strand counts, and one was overwriting the other. In workflow context, we do not know if first and second strand designations are correct (we can change these in the presenter). Altered the script so that we still create EDA files for both profiles, but with different names so we don't overwrite them.
4. Noticed that we were loading mean_raw_count values for both unique and non-unique profiles. This is used in intron junction context, where we only consider unique mappers - therefore no longer loading these values for nonunique profiles.

Tested locally on both unstranded and stranded datasets, with and without replicates.