### PR TITLE
Fix unpack step of owl ontology loading.

### DIFF
--- a/Load/bin/parseOwlFileToDBFile.pl
+++ b/Load/bin/parseOwlFileToDBFile.pl
@@ -22,7 +22,7 @@ my ($help, $owlFile);
 
 my $dbFile = "$owlFile.sqlite";
 my $md5File = "$owlFile.md5";
-my $name = basename ($dbFile);
+my $name = basename ($owlFile);
 
 # create dbfile atomically
 # otherwise another process might start reading from an incomplete file

--- a/Load/bin/parseOwlFileToDBFile.pl
+++ b/Load/bin/parseOwlFileToDBFile.pl
@@ -5,7 +5,9 @@ use Digest::MD5;
 use Getopt::Long;
 use RDF::Trine;
 use File::Basename qw/basename dirname/;
-
+use File::Temp qw/tempfile/;
+use File::Copy qw/move/;
+use RDF::Trine::Store::DBI;
 
 my ($help, $owlFile);
 
@@ -20,24 +22,30 @@ my ($help, $owlFile);
 
 my $dbFile = "$owlFile.sqlite";
 my $md5File = "$owlFile.md5";
+my $name = basename ($dbFile);
 
 # create dbfile atomically
 # otherwise another process might start reading from an incomplete file
-my ($fh, $tempFilePath) = tempfile( "tmpfileXXXXX", DIR => dirname($dbfile));
+my ($fh, $tempFilePath) = tempfile( "tmpfileXXXXX", DIR => dirname($dbFile));
+$fh->autoflush;
+
+my $dbh = DBI->connect("dbi:SQLite:dbname=$tempFilePath","","");
+$dbh->{AutoCommit} = 1;
+
 my $model = RDF::Trine::Model->new(
   RDF::Trine::Store::DBI->new(
     $name,
-    "dbi:SQLite:dbname=$tempFilePath",
-    '',  # no username
-    '',  # no password
+    $dbh
   ),
 );
 my $parser = RDF::Trine::Parser->new('rdfxml');
 $parser->parse_file_into_model(undef, $owlFile, $model);
-close($fh);
-move("$tempFilePath", "$dbfile");
-
 print STDERR $model->size . " RDF statements parsed\n";
+
+move("$tempFilePath", "$dbFile");
+
+$dbh->disconnect();
+close($fh);
 
 my $ctx = Digest::MD5->new;
 open(my $fh, $owlFile);


### PR DESCRIPTION
The script created the sqlite database with a different name than what the OWLReader class was expecting therefore causing the reader to create a new empty database with that different name instead of reading the existing one we've created in the .sqlite file. 

This fixes that problem.