### PR TITLE
Scope patch psql scripts to a single organism via :ORG_ABBREV

### DIFF
--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -180,17 +180,6 @@ where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId
 delete from apidb.AaSequenceAttribute
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
-
-drop table if exists apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV;
-create table apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV as
-select *
-from apidb.MassSpecSummary
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
-
-delete from apidb.MassSpecSummary
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
-
-
 drop table if exists apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV as
 select *
@@ -218,6 +207,26 @@ from apidb.AASequenceEpitope
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 delete from apidb.AASequenceEpitope
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+
+drop table if exists apidb.pgp2_TransMembraneAAFeature_:CLEAN_ORG_ABBREV;
+create table apidb.pgp2_TransMembraneAAFeature_:CLEAN_ORG_ABBREV as
+select *
+from dots.TransMembraneAAFeature
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+delete from dots.TransMembraneAAFeature
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+
+drop table if exists apidb.pgp2_SignalPeptideFeature_:CLEAN_ORG_ABBREV;
+create table apidb.pgp2_SignalPeptideFeature_:CLEAN_ORG_ABBREV as
+select *
+from dots.SignalPeptideFeature
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+delete from dots.SignalPeptideFeature
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
@@ -268,9 +277,11 @@ drop table apidb.pgp2_AaFeatureExon_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_AaLocation_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_AaFeature_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_AaSequenceAttribute_:CLEAN_ORG_ABBREV;
-drop table apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_PDBSimilarity_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_AASequenceEpitope_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_TransMembraneAAFeature_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_SignalPeptideFeature_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_TranslatedAaFeature_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_FeatureLocation_:CLEAN_ORG_ABBREV;

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -7,6 +7,7 @@
 --
 
 -- organism-scoped gene na_feature_ids
+drop table if exists apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV;
 create table apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV as
 select gf.na_feature_id
 from dots.GeneFeature gf
@@ -33,17 +34,20 @@ where is_pseudo = 0
   and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
 
 -- create lists of IDs of affected NaFeature / AaFeature / AaSequence records
+drop table if exists apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV;
 create table apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV as
 select t.na_feature_id
 from dots.Transcript t
   join apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV pg on t.parent_id = pg.na_feature_id
 where t.is_pseudo = 1;
 
+drop table if exists apidb.new_pseudoAaFeatureId_:CLEAN_ORG_ABBREV;
 create table apidb.new_pseudoAaFeatureId_:CLEAN_ORG_ABBREV as
 select taf.aa_feature_id
 from dots.TranslatedAaFeature taf
   join apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV pnf on taf.na_feature_id = pnf.na_feature_id;
 
+drop table if exists apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV;
 create table apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV as
 select taf.aa_sequence_id
 from dots.TranslatedAaFeature taf
@@ -52,6 +56,7 @@ from dots.TranslatedAaFeature taf
 --------------------------------------------------------------------------------
 -- set coding start/end NULL
 
+drop table if exists apidb.pgp2_RnaFeatureExon_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_RnaFeatureExon_:CLEAN_ORG_ABBREV as
 select *
 from dots.RnaFeatureExon
@@ -66,6 +71,7 @@ where (coding_start is not null or coding_end is not null)
 
 --------------------------------------------------------------------------------
 
+drop table if exists apidb.pgp2_SecondaryStructureCall_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_SecondaryStructureCall_:CLEAN_ORG_ABBREV as
 select *
 from dots.SecondaryStructureCall
@@ -83,6 +89,7 @@ where secondary_structure_id in (
 );
 
 
+drop table if exists apidb.pgp2_SecondaryStructure_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_SecondaryStructure_:CLEAN_ORG_ABBREV as
 select *
 from dots.SecondaryStructure
@@ -92,6 +99,7 @@ delete from dots.SecondaryStructure
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_DbRefAaFeature_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_DbRefAaFeature_:CLEAN_ORG_ABBREV as
 select *
 from dots.DbRefAaFeature
@@ -109,6 +117,7 @@ where aa_feature_id in (
 );
 
 
+drop table if exists apidb.pgp2_AaFeatureExon_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_AaFeatureExon_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaFeatureExon
@@ -126,6 +135,7 @@ where aa_feature_id in (
 );
 
 
+drop table if exists apidb.pgp2_AaLocation_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_AaLocation_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaLocation
@@ -143,6 +153,7 @@ where aa_feature_id in (
 );
 
 
+drop table if exists apidb.pgp2_AaFeature_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_AaFeature_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaFeature
@@ -152,6 +163,7 @@ delete from dots.AaFeature
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_AaSequenceAttribute_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_AaSequenceAttribute_:CLEAN_ORG_ABBREV as
 select *
 from apidb.AaSequenceAttribute
@@ -161,6 +173,7 @@ delete from apidb.AaSequenceAttribute
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV as
 select *
 from apidb.MassSpecSummary
@@ -170,6 +183,7 @@ delete from apidb.MassSpecSummary
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaSequenceEnzymeClass
@@ -179,6 +193,7 @@ delete from dots.AaSequenceEnzymeClass
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_PDBSimilarity_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_PDBSimilarity_:CLEAN_ORG_ABBREV as
 select *
 from apidb.PDBSimilarity
@@ -188,6 +203,7 @@ delete from apidb.PDBSimilarity
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV as
 select *
 from dots.TranslatedAASequence
@@ -198,6 +214,7 @@ where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId
 
 --------------------------------------------------------------------------------
 
+drop table if exists apidb.pgp2_TranslatedAaFeature_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_TranslatedAaFeature_:CLEAN_ORG_ABBREV as
 select *
 from dots.TranslatedAaFeature
@@ -207,6 +224,7 @@ delete from dots.TranslatedAaFeature
 where na_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_FeatureLocation_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_FeatureLocation_:CLEAN_ORG_ABBREV as
 select *
 from apidb.FeatureLocation

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -210,6 +210,16 @@ delete from apidb.PDBSimilarity
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+drop table if exists apidb.pgp2_AASequenceEpitope_:CLEAN_ORG_ABBREV;
+create table apidb.pgp2_AASequenceEpitope_:CLEAN_ORG_ABBREV as
+select *
+from apidb.AASequenceEpitope
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+delete from apidb.AASequenceEpitope
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+
 drop table if exists apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV;
 create table apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV as
 select *

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -33,6 +33,11 @@ where is_pseudo = 0
   and name = 'pseudogene'
   and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
 
+update dots.GeneFeature
+set name = 'pseudogene'
+where name = 'pseudogene_with_CDS'
+  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
+
 -- create lists of IDs of affected NaFeature / AaFeature / AaSequence records
 drop table if exists apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV;
 create table apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV as

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -27,16 +27,18 @@ where is_pseudo = 0
     where gf.name = 'pseudogene'
   );
 
+
+update dots.GeneFeature
+set name = 'pseudogene'
+where name = 'pseudogene_with_CDS'
+  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
+
 update dots.GeneFeature
 set is_pseudo = 1
 where is_pseudo = 0
   and name = 'pseudogene'
   and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
 
-update dots.GeneFeature
-set name = 'pseudogene'
-where name = 'pseudogene_with_CDS'
-  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
 
 -- create lists of IDs of affected NaFeature / AaFeature / AaSequence records
 drop table if exists apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV;

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -179,6 +179,15 @@ delete from dots.AaSequenceEnzymeClass
 where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
+create table apidb.pgp2_PDBSimilarity_:CLEAN_ORG_ABBREV as
+select *
+from apidb.PDBSimilarity
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+delete from apidb.PDBSimilarity
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
+
+
 create table apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV as
 select *
 from dots.TranslatedAASequence
@@ -225,6 +234,7 @@ drop table apidb.pgp2_AaFeature_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_AaSequenceAttribute_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_PDBSimilarity_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_TranslatedAaFeature_:CLEAN_ORG_ABBREV;
 drop table apidb.pgp2_FeatureLocation_:CLEAN_ORG_ABBREV;

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -1,0 +1,230 @@
+--
+-- patch script for unwanted exons and proteins on pseudogenes
+--
+-- creates tables listing na_feature_ids (of transcripts), aa_feature_ids, and
+-- aa_sequence_ids to remove, and copies affected records of each table X to a
+-- new table "PGP_X" (for "pseudogenes patch")
+--
+
+-- organism-scoped gene na_feature_ids
+create table apidb.pgp_pseudoGeneId as
+select gf.na_feature_id
+from dots.GeneFeature gf
+  join dots.NaSequence ns on gf.na_sequence_id = ns.na_sequence_id
+  join apidb.Organism o on ns.taxon_id = o.taxon_id
+where o.public_abbrev = ':ORG_ABBREV';
+
+-- set IS_PSEUDO for genes named "pseudogene", and their transcripts, where it isn't already
+update dots.Transcript
+set is_pseudo = 1
+where is_pseudo = 0
+  and na_feature_id in (
+    select t.na_feature_id
+    from dots.Transcript t
+      join dots.GeneFeature gf on t.parent_id = gf.na_feature_id
+      join apidb.pgp_pseudoGeneId pg on gf.na_feature_id = pg.na_feature_id
+    where gf.name = 'pseudogene'
+  );
+
+update dots.GeneFeature
+set is_pseudo = 1
+where is_pseudo = 0
+  and name = 'pseudogene'
+  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId);
+
+-- create lists of IDs of affected NaFeature / AaFeature / AaSequence records
+create table apidb.new_pseudoNaFeatureId as
+select t.na_feature_id
+from dots.Transcript t
+  join apidb.pgp_pseudoGeneId pg on t.parent_id = pg.na_feature_id
+where t.is_pseudo = 1;
+
+create table apidb.new_pseudoAaFeatureId as
+select taf.aa_feature_id
+from dots.TranslatedAaFeature taf
+  join apidb.new_pseudoNaFeatureId pnf on taf.na_feature_id = pnf.na_feature_id;
+
+create table apidb.new_pseudoAaSequenceId as
+select taf.aa_sequence_id
+from dots.TranslatedAaFeature taf
+  join apidb.new_pseudoNaFeatureId pnf on taf.na_feature_id = pnf.na_feature_id;
+
+--------------------------------------------------------------------------------
+-- set coding start/end NULL
+
+create table apidb.pgp2_RnaFeatureExon as
+select *
+from dots.RnaFeatureExon
+where (coding_start is not null or coding_end is not null)
+  and rna_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+
+update dots.RnaFeatureExon
+set coding_start = null,
+    coding_end = null
+where (coding_start is not null or coding_end is not null)
+  and rna_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+
+--------------------------------------------------------------------------------
+
+create table apidb.pgp2_SecondaryStructureCall as
+select *
+from dots.SecondaryStructureCall
+where secondary_structure_id in (
+  select ss.secondary_structure_id
+  from dots.SecondaryStructure ss
+    join apidb.new_pseudoAaSequenceId pasi on ss.aa_sequence_id = pasi.aa_sequence_id
+);
+
+delete from dots.SecondaryStructureCall
+where secondary_structure_id in (
+  select ss.secondary_structure_id
+  from dots.SecondaryStructure ss
+    join apidb.new_pseudoAaSequenceId pasi on ss.aa_sequence_id = pasi.aa_sequence_id
+);
+
+
+create table apidb.pgp2_SecondaryStructure as
+select *
+from dots.SecondaryStructure
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+delete from dots.SecondaryStructure
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+
+create table apidb.pgp2_DbRefAaFeature as
+select *
+from dots.DbRefAaFeature
+where aa_feature_id in (
+  select aaf.aa_feature_id
+  from dots.AaFeature aaf
+    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+);
+
+delete from dots.DbRefAaFeature
+where aa_feature_id in (
+  select aaf.aa_feature_id
+  from dots.AaFeature aaf
+    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+);
+
+
+create table apidb.pgp2_AaFeatureExon as
+select *
+from dots.AaFeatureExon
+where aa_feature_id in (
+  select aaf.aa_feature_id
+  from dots.AaFeature aaf
+    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+);
+
+delete from dots.AaFeatureExon
+where aa_feature_id in (
+  select aaf.aa_feature_id
+  from dots.AaFeature aaf
+    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+);
+
+
+create table apidb.pgp2_AaLocation as
+select *
+from dots.AaLocation
+where aa_feature_id in (
+  select aaf.aa_feature_id
+  from dots.AaFeature aaf
+    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+);
+
+delete from dots.AaLocation
+where aa_feature_id in (
+  select aaf.aa_feature_id
+  from dots.AaFeature aaf
+    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+);
+
+
+create table apidb.pgp2_AaFeature as
+select *
+from dots.AaFeature
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+delete from dots.AaFeature
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+
+create table apidb.pgp2_AaSequenceAttribute as
+select *
+from apidb.AaSequenceAttribute
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+delete from apidb.AaSequenceAttribute
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+
+create table apidb.pgp2_MassSpecSummary as
+select *
+from apidb.MassSpecSummary
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+delete from apidb.MassSpecSummary
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+
+create table apidb.pgp2_AaSequenceEnzymeClass as
+select *
+from dots.AaSequenceEnzymeClass
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+delete from dots.AaSequenceEnzymeClass
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+
+create table apidb.pgp2_TranslatedAASequence as
+select *
+from dots.TranslatedAASequence
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+delete from dots.TranslatedAASequence
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+
+--------------------------------------------------------------------------------
+
+create table apidb.pgp2_TranslatedAaFeature as
+select *
+from dots.TranslatedAaFeature
+where na_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+
+delete from dots.TranslatedAaFeature
+where na_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+
+
+create table apidb.pgp2_FeatureLocation as
+select *
+from apidb.FeatureLocation
+where feature_type in ('UTR', 'CDS')
+  and parent_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+
+delete from apidb.FeatureLocation
+where feature_type in ('UTR', 'CDS')
+  and parent_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+
+--------------------------------------------------------------------------------
+-- cleanup
+
+drop table apidb.pgp_pseudoGeneId;
+drop table apidb.new_pseudoNaFeatureId;
+drop table apidb.new_pseudoAaFeatureId;
+drop table apidb.new_pseudoAaSequenceId;
+drop table apidb.pgp2_RnaFeatureExon;
+drop table apidb.pgp2_SecondaryStructureCall;
+drop table apidb.pgp2_SecondaryStructure;
+drop table apidb.pgp2_DbRefAaFeature;
+drop table apidb.pgp2_AaFeatureExon;
+drop table apidb.pgp2_AaLocation;
+drop table apidb.pgp2_AaFeature;
+drop table apidb.pgp2_AaSequenceAttribute;
+drop table apidb.pgp2_MassSpecSummary;
+drop table apidb.pgp2_AaSequenceEnzymeClass;
+drop table apidb.pgp2_TranslatedAASequence;
+drop table apidb.pgp2_TranslatedAaFeature;
+drop table apidb.pgp2_FeatureLocation;

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -15,6 +15,12 @@ from dots.GeneFeature gf
   join apidb.Organism o on ns.taxon_id = o.taxon_id
 where o.public_abbrev = ':ORG_ABBREV';
 
+
+update dots.GeneFeature
+set name = 'pseudogene'
+where name = 'pseudogene_with_CDS'
+  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
+
 -- set IS_PSEUDO for genes named "pseudogene", and their transcripts, where it isn't already
 update dots.Transcript
 set is_pseudo = 1
@@ -27,11 +33,6 @@ where is_pseudo = 0
     where gf.name = 'pseudogene'
   );
 
-
-update dots.GeneFeature
-set name = 'pseudogene'
-where name = 'pseudogene_with_CDS'
-  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
 
 update dots.GeneFeature
 set is_pseudo = 1

--- a/Load/lib/psql/patches/pseudogenicCDS.psql
+++ b/Load/lib/psql/patches/pseudogenicCDS.psql
@@ -7,7 +7,7 @@
 --
 
 -- organism-scoped gene na_feature_ids
-create table apidb.pgp_pseudoGeneId as
+create table apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV as
 select gf.na_feature_id
 from dots.GeneFeature gf
   join dots.NaSequence ns on gf.na_sequence_id = ns.na_sequence_id
@@ -22,7 +22,7 @@ where is_pseudo = 0
     select t.na_feature_id
     from dots.Transcript t
       join dots.GeneFeature gf on t.parent_id = gf.na_feature_id
-      join apidb.pgp_pseudoGeneId pg on gf.na_feature_id = pg.na_feature_id
+      join apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV pg on gf.na_feature_id = pg.na_feature_id
     where gf.name = 'pseudogene'
   );
 
@@ -30,201 +30,201 @@ update dots.GeneFeature
 set is_pseudo = 1
 where is_pseudo = 0
   and name = 'pseudogene'
-  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId);
+  and na_feature_id in (select na_feature_id from apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV);
 
 -- create lists of IDs of affected NaFeature / AaFeature / AaSequence records
-create table apidb.new_pseudoNaFeatureId as
+create table apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV as
 select t.na_feature_id
 from dots.Transcript t
-  join apidb.pgp_pseudoGeneId pg on t.parent_id = pg.na_feature_id
+  join apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV pg on t.parent_id = pg.na_feature_id
 where t.is_pseudo = 1;
 
-create table apidb.new_pseudoAaFeatureId as
+create table apidb.new_pseudoAaFeatureId_:CLEAN_ORG_ABBREV as
 select taf.aa_feature_id
 from dots.TranslatedAaFeature taf
-  join apidb.new_pseudoNaFeatureId pnf on taf.na_feature_id = pnf.na_feature_id;
+  join apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV pnf on taf.na_feature_id = pnf.na_feature_id;
 
-create table apidb.new_pseudoAaSequenceId as
+create table apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV as
 select taf.aa_sequence_id
 from dots.TranslatedAaFeature taf
-  join apidb.new_pseudoNaFeatureId pnf on taf.na_feature_id = pnf.na_feature_id;
+  join apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV pnf on taf.na_feature_id = pnf.na_feature_id;
 
 --------------------------------------------------------------------------------
 -- set coding start/end NULL
 
-create table apidb.pgp2_RnaFeatureExon as
+create table apidb.pgp2_RnaFeatureExon_:CLEAN_ORG_ABBREV as
 select *
 from dots.RnaFeatureExon
 where (coding_start is not null or coding_end is not null)
-  and rna_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+  and rna_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV);
 
 update dots.RnaFeatureExon
 set coding_start = null,
     coding_end = null
 where (coding_start is not null or coding_end is not null)
-  and rna_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+  and rna_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV);
 
 --------------------------------------------------------------------------------
 
-create table apidb.pgp2_SecondaryStructureCall as
+create table apidb.pgp2_SecondaryStructureCall_:CLEAN_ORG_ABBREV as
 select *
 from dots.SecondaryStructureCall
 where secondary_structure_id in (
   select ss.secondary_structure_id
   from dots.SecondaryStructure ss
-    join apidb.new_pseudoAaSequenceId pasi on ss.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on ss.aa_sequence_id = pasi.aa_sequence_id
 );
 
 delete from dots.SecondaryStructureCall
 where secondary_structure_id in (
   select ss.secondary_structure_id
   from dots.SecondaryStructure ss
-    join apidb.new_pseudoAaSequenceId pasi on ss.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on ss.aa_sequence_id = pasi.aa_sequence_id
 );
 
 
-create table apidb.pgp2_SecondaryStructure as
+create table apidb.pgp2_SecondaryStructure_:CLEAN_ORG_ABBREV as
 select *
 from dots.SecondaryStructure
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 delete from dots.SecondaryStructure
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
-create table apidb.pgp2_DbRefAaFeature as
+create table apidb.pgp2_DbRefAaFeature_:CLEAN_ORG_ABBREV as
 select *
 from dots.DbRefAaFeature
 where aa_feature_id in (
   select aaf.aa_feature_id
   from dots.AaFeature aaf
-    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
 );
 
 delete from dots.DbRefAaFeature
 where aa_feature_id in (
   select aaf.aa_feature_id
   from dots.AaFeature aaf
-    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
 );
 
 
-create table apidb.pgp2_AaFeatureExon as
+create table apidb.pgp2_AaFeatureExon_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaFeatureExon
 where aa_feature_id in (
   select aaf.aa_feature_id
   from dots.AaFeature aaf
-    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
 );
 
 delete from dots.AaFeatureExon
 where aa_feature_id in (
   select aaf.aa_feature_id
   from dots.AaFeature aaf
-    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
 );
 
 
-create table apidb.pgp2_AaLocation as
+create table apidb.pgp2_AaLocation_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaLocation
 where aa_feature_id in (
   select aaf.aa_feature_id
   from dots.AaFeature aaf
-    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
 );
 
 delete from dots.AaLocation
 where aa_feature_id in (
   select aaf.aa_feature_id
   from dots.AaFeature aaf
-    join apidb.new_pseudoAaSequenceId pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
+    join apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV pasi on aaf.aa_sequence_id = pasi.aa_sequence_id
 );
 
 
-create table apidb.pgp2_AaFeature as
+create table apidb.pgp2_AaFeature_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaFeature
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 delete from dots.AaFeature
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
-create table apidb.pgp2_AaSequenceAttribute as
+create table apidb.pgp2_AaSequenceAttribute_:CLEAN_ORG_ABBREV as
 select *
 from apidb.AaSequenceAttribute
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 delete from apidb.AaSequenceAttribute
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
-create table apidb.pgp2_MassSpecSummary as
+create table apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV as
 select *
 from apidb.MassSpecSummary
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 delete from apidb.MassSpecSummary
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
-create table apidb.pgp2_AaSequenceEnzymeClass as
+create table apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV as
 select *
 from dots.AaSequenceEnzymeClass
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 delete from dots.AaSequenceEnzymeClass
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 
-create table apidb.pgp2_TranslatedAASequence as
+create table apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV as
 select *
 from dots.TranslatedAASequence
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 delete from dots.TranslatedAASequence
-where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId);
+where aa_sequence_id in (select aa_sequence_id from apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV);
 
 --------------------------------------------------------------------------------
 
-create table apidb.pgp2_TranslatedAaFeature as
+create table apidb.pgp2_TranslatedAaFeature_:CLEAN_ORG_ABBREV as
 select *
 from dots.TranslatedAaFeature
-where na_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+where na_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV);
 
 delete from dots.TranslatedAaFeature
-where na_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+where na_feature_id in (select na_feature_id from apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV);
 
 
-create table apidb.pgp2_FeatureLocation as
+create table apidb.pgp2_FeatureLocation_:CLEAN_ORG_ABBREV as
 select *
 from apidb.FeatureLocation
 where feature_type in ('UTR', 'CDS')
-  and parent_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+  and parent_id in (select na_feature_id from apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV);
 
 delete from apidb.FeatureLocation
 where feature_type in ('UTR', 'CDS')
-  and parent_id in (select na_feature_id from apidb.new_pseudoNaFeatureId);
+  and parent_id in (select na_feature_id from apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV);
 
 --------------------------------------------------------------------------------
 -- cleanup
 
-drop table apidb.pgp_pseudoGeneId;
-drop table apidb.new_pseudoNaFeatureId;
-drop table apidb.new_pseudoAaFeatureId;
-drop table apidb.new_pseudoAaSequenceId;
-drop table apidb.pgp2_RnaFeatureExon;
-drop table apidb.pgp2_SecondaryStructureCall;
-drop table apidb.pgp2_SecondaryStructure;
-drop table apidb.pgp2_DbRefAaFeature;
-drop table apidb.pgp2_AaFeatureExon;
-drop table apidb.pgp2_AaLocation;
-drop table apidb.pgp2_AaFeature;
-drop table apidb.pgp2_AaSequenceAttribute;
-drop table apidb.pgp2_MassSpecSummary;
-drop table apidb.pgp2_AaSequenceEnzymeClass;
-drop table apidb.pgp2_TranslatedAASequence;
-drop table apidb.pgp2_TranslatedAaFeature;
-drop table apidb.pgp2_FeatureLocation;
+drop table apidb.pgp_pseudoGeneId_:CLEAN_ORG_ABBREV;
+drop table apidb.new_pseudoNaFeatureId_:CLEAN_ORG_ABBREV;
+drop table apidb.new_pseudoAaFeatureId_:CLEAN_ORG_ABBREV;
+drop table apidb.new_pseudoAaSequenceId_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_RnaFeatureExon_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_SecondaryStructureCall_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_SecondaryStructure_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_DbRefAaFeature_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_AaFeatureExon_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_AaLocation_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_AaFeature_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_AaSequenceAttribute_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_MassSpecSummary_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_AaSequenceEnzymeClass_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_TranslatedAASequence_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_TranslatedAaFeature_:CLEAN_ORG_ABBREV;
+drop table apidb.pgp2_FeatureLocation_:CLEAN_ORG_ABBREV;

--- a/Load/lib/psql/patches/uniprotProductNames.psql
+++ b/Load/lib/psql/patches/uniprotProductNames.psql
@@ -1,11 +1,11 @@
 -- genefeature
 UPDATE dots.GeneFeature
 SET product = NULL
-WHERE product ~ 'Source:UniProtKB'
+WHERE product ~* 'Source:UniProtKB'
   AND na_feature_id IN (
     SELECT gf.na_feature_id
     FROM dots.GeneFeature gf
       JOIN dots.NaSequence ns ON gf.na_sequence_id = ns.na_sequence_id
       JOIN apidb.Organism o ON ns.taxon_id = o.taxon_id
-    WHERE o.public_abbrev = ':ORG_ABBREV'
+    WHERE o.abbrev = ':ORG_ABBREV'
   );

--- a/Load/lib/psql/patches/uniprotProductNames.psql
+++ b/Load/lib/psql/patches/uniprotProductNames.psql
@@ -1,0 +1,11 @@
+-- genefeature
+UPDATE dots.GeneFeature
+SET product = NULL
+WHERE product ~ 'Source:UniProtKB'
+  AND na_feature_id IN (
+    SELECT gf.na_feature_id
+    FROM dots.GeneFeature gf
+      JOIN dots.NaSequence ns ON gf.na_sequence_id = ns.na_sequence_id
+      JOIN apidb.Organism o ON ns.taxon_id = o.taxon_id
+    WHERE o.public_abbrev = ':ORG_ABBREV'
+  );

--- a/Load/plugin/perl/PatchGenomeAndAnnotation.pm
+++ b/Load/plugin/perl/PatchGenomeAndAnnotation.pm
@@ -118,7 +118,7 @@ sub processPsqlFile {
   open my $fh, '<', $psqlFile or $self->error("error opening $psqlFile: $!");
   my $sqls = do { local $/; <$fh> };
 
-  my $newSqls = ApiCommonData::Load::InstantiatePsql::instantiateSql($sqls, $organismAbbrev);
+  my $newSqls = ApiCommonData::Load::InstantiatePsql::instantiateSql($sqls, undef, undef, $organismAbbrev);
 
   my @sqlList = split(/;\n\s*/, $newSqls);
   foreach my $sql (@sqlList) {


### PR DESCRIPTION
## Summary
- Fix `instantiateSql` call in `PatchGenomeAndAnnotation.pm` — `$organismAbbrev` was landing in the `$tableName` slot (position 2); now correctly passed as position 4 with `undef` placeholders
- Rewrite `pseudogenicCDS.psql`: organism-scoped via `GeneFeature → NaSequence → Organism` join using `:ORG_ABBREV` macro, all created tables prefixed to `apidb` schema, DROP TABLE cleanup block added, Oracle implicit-schema references removed
- Add organism scoping to `uniprotProductNames.psql` using same join pattern

## Test Plan
- [ ] Run plugin against a test organism and verify only that organism's pseudogene records are affected
- [ ] Confirm `apidb.pgp_*` and `apidb.new_pseudo*` tables are created and dropped cleanly
- [ ] Verify `uniprotProductNames.psql` only nulls `product` for the target organism

🤖 Generated with [Claude Code](https://claude.com/claude-code)