### PR TITLE
Load mergeExperiments variation .dat files into ApiDB variation tables

### DIFF
--- a/Load/lib/perl/VariationLoader.pm
+++ b/Load/lib/perl/VariationLoader.pm
@@ -107,4 +107,33 @@ sub transformTranscriptProduct {
   return $n;
 }
 
+sub transformVariationEffect {
+  my ($inFh, $outFh, $map) = @_;
+  my $header = <$inFh>;
+  die "snpeff.dat: empty file\n" unless defined $header;
+  my $cols = parseHeader($header);
+  die "snpeff.dat: expected 8 columns, got " . scalar(@$cols) . "\n"
+    unless @$cols == 8;
+  die "snpeff.dat: unexpected header (want location first)\n"
+    unless $cols->[0] eq 'location';
+
+  my $n = 0;
+  while (my $line = <$inFh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    die "snpeff.dat line $.: expected 8 fields, got " . scalar(@f) . "\n"
+      unless @f == 8;
+    my ($loc, $seq, $allele, $tid, $impact, $effect, $hgvsc, $source) = @f;
+    my $nfid = '';                       # empty -> NULL for intergenic
+    if ($tid ne '') {
+      $nfid = $map->{$tid};
+      die "snpeff.dat line $.: transcript_id '$tid' not found for this organism\n"
+        unless defined $nfid;
+    }
+    print $outFh join("\t", $seq, $loc, $allele, $nfid, $impact, $effect, $hgvsc, $source), "\n";
+    $n++;
+  }
+  return $n;
+}
+
 1;

--- a/Load/lib/perl/VariationLoader.pm
+++ b/Load/lib/perl/VariationLoader.pm
@@ -77,4 +77,34 @@ sub transformVariationFeature {
   return $n;
 }
 
+sub transformTranscriptProduct {
+  my ($inFh, $outFh, $map) = @_;
+  my $header = <$inFh>;
+  die "transcript_product.dat: empty file\n" unless defined $header;
+  my $cols = parseHeader($header);
+  die "transcript_product.dat: expected 13 columns, got " . scalar(@$cols) . "\n"
+    unless @$cols == 13;
+  die "transcript_product.dat: unexpected header (want seq_id first)\n"
+    unless $cols->[0] eq 'seq_id';
+
+  my $n = 0;
+  while (my $line = <$inFh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    die "transcript_product.dat line $.: expected 13 fields, got " . scalar(@f) . "\n"
+      unless @f == 13;
+    my $tid = $f[2];
+    die "transcript_product.dat line $.: empty transcript_id (na_feature_id is NOT NULL)\n"
+      if $tid eq '';
+    my $nfid = $map->{$tid};
+    die "transcript_product.dat line $.: transcript_id '$tid' not found for this organism\n"
+      unless defined $nfid;
+    # out: seq_id, location, na_feature_id, cols 4..11 (pos_in_cds..matches_ref_product), hgvs_p
+    # drop col index 11 (downstream_of_frameshift_strain_ids); hgvs_p is index 12
+    print $outFh join("\t", @f[0,1], $nfid, @f[3..10], $f[12]), "\n";
+    $n++;
+  }
+  return $n;
+}
+
 1;

--- a/Load/lib/perl/VariationLoader.pm
+++ b/Load/lib/perl/VariationLoader.pm
@@ -54,4 +54,27 @@ sub buildSourceId {
   return "Variant_${seq}_${loc}";
 }
 
+sub transformVariationFeature {
+  my ($inFh, $outFh, $extDbRlsId) = @_;
+  my $header = <$inFh>;
+  die "variationFeature.dat: empty file\n" unless defined $header;
+  my $cols = parseHeader($header);
+  die "variationFeature.dat: expected 31 columns, got " . scalar(@$cols) . "\n"
+    unless @$cols == 31;
+  die "variationFeature.dat: unexpected header (want location, seq_id first)\n"
+    unless $cols->[0] eq 'location' && $cols->[1] eq 'seq_id';
+
+  my $n = 0;
+  while (my $line = <$inFh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    die "variationFeature.dat line $.: expected 31 fields, got " . scalar(@f) . "\n"
+      unless @f == 31;
+    my ($loc, $seq) = @f[0, 1];
+    print $outFh join("\t", buildSourceId($seq, $loc), $seq, $loc, @f[2..30], $extDbRlsId), "\n";
+    $n++;
+  }
+  return $n;
+}
+
 1;

--- a/Load/lib/perl/VariationLoader.pm
+++ b/Load/lib/perl/VariationLoader.pm
@@ -1,0 +1,57 @@
+package ApiCommonData::Load::VariationLoader;
+
+use strict;
+use warnings;
+
+use Exporter 'import';
+our @EXPORT_OK = qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  parseHeader buildSourceId
+  transformVariationFeature transformTranscriptProduct transformVariationEffect
+/;
+
+# Canonical output column order. The transforms below emit values in exactly
+# this order; the plugin uses these same lists to build each \copy field list.
+# Keep the two in lockstep — the unit tests assert the counts match.
+
+sub variationFeatureColumns {
+  return [ qw/
+    source_id sequence_source_id location reference_strain is_coding variant_type
+    distinct_strain_count called_strain_count no_call_strain_count call_rate
+    total_ploidy_count ref_allele_frequency het_strain_count
+    snp_ref_allele snp_major_allele snp_major_allele_frequency snp_major_allele_strain_count
+    snp_minor_allele snp_minor_allele_frequency snp_minor_allele_strain_count
+    snp_major_genomic_hgvs snp_minor_genomic_hgvs
+    indel_ref_allele indel_major_allele indel_major_allele_frequency indel_major_allele_strain_count
+    indel_minor_allele indel_minor_allele_frequency indel_minor_allele_strain_count
+    indel_major_genomic_hgvs indel_minor_genomic_hgvs indel_frame_effect
+    external_database_release_id
+  / ];
+}
+
+sub transcriptProductColumns {
+  return [ qw/
+    sequence_source_id location na_feature_id pos_in_cds pos_in_protein codon
+    pos_in_codon strain_count product matches_ref_codon matches_ref_product hgvs_p
+  / ];
+}
+
+sub variationEffectColumns {
+  return [ qw/
+    sequence_source_id location allele na_feature_id impact effect hgvs_c source
+  / ];
+}
+
+sub parseHeader {
+  my ($line) = @_;
+  chomp $line;
+  $line =~ s/^#//;
+  return [ split /\t/, $line, -1 ];
+}
+
+sub buildSourceId {
+  my ($seq, $loc) = @_;
+  return "Variant_${seq}_${loc}";
+}
+
+1;

--- a/Load/lib/perl/VariationLoader.pm
+++ b/Load/lib/perl/VariationLoader.pm
@@ -13,6 +13,11 @@ our @EXPORT_OK = qw/
 # Canonical output column order. The transforms below emit values in exactly
 # this order; the plugin uses these same lists to build each \copy field list.
 # Keep the two in lockstep — the unit tests assert the counts match.
+#
+# modification_date is deliberately NOT in these lists. All three tables declare
+# DEFAULT localtimestamp (createVariationTables.sql), so Postgres stamps it as
+# each COPY row lands — the database clock, not the loader host's. Adding it here
+# would override that with a Perl-side timestamp; leave it out.
 
 sub variationFeatureColumns {
   return [ qw/

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -110,4 +110,70 @@ sub validateSequenceIds {
   $self->log("Validated " . scalar(keys %seen) . " distinct sequence ids");
 }
 
+# Parse host/port/dbname out of the gus.config dbiDsn. NOTE: the port matters —
+# the default config runs on 5433, and psql defaults to 5432, so an omitted port
+# silently hits the wrong database.
+sub getPsqlConnection {
+  my ($self) = @_;
+  my $cfg = GUS::Supported::GusConfig->new();
+  my $dsn = $cfg->getDbiDsn();     # dbi:Pg:dbname=...;host=...;port=...
+  my ($dbname) = $dsn =~ /dbname=([^;]+)/;
+  my ($host)   = $dsn =~ /host=([^;]+)/;
+  my ($port)   = $dsn =~ /port=([^;]+)/;
+  return {
+    login    => $cfg->getDatabaseLogin(),
+    password => $cfg->getDatabasePassword(),
+    dbname   => $dbname,
+    host     => $host || 'localhost',
+    port     => $port || 5432,
+  };
+}
+
+# Build a single-line \copy command. Psql.pm's getCommand() emits multi-line,
+# which fails in a psql -f script, so we assemble it here. QUOTE '`' matches
+# Psql.pm and is verified against this data (no backticks, double quotes, or CRs
+# occur in any field); the data is unquoted so QUOTE only needs a byte that
+# never appears.
+sub copyCommand {
+  my ($self, $table, $columns, $file) = @_;
+  my $cols = join(", ", @$columns);
+  return "\\copy $table ($cols) FROM '$file' "
+       . "WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')";
+}
+
+sub loadAll {
+  my ($self, $schema, $extDbRlsId, $vfFile, $tpFile, $veFile) = @_;
+  my $conn = $self->getPsqlConnection();
+  my $dir  = tempdir(CLEANUP => 1);
+  my $sqlFile = "$dir/load.sql";
+
+  open(my $sql, '>', $sqlFile) or $self->error("Cannot write $sqlFile: $!");
+  print $sql "BEGIN;\n";
+  print $sql "DELETE FROM $schema.VariationFeature WHERE external_database_release_id = $extDbRlsId;\n";
+  print $sql $self->copyCommand("$schema.VariationFeature",           variationFeatureColumns(),  $vfFile) . "\n";
+  print $sql $self->copyCommand("$schema.VariationTranscriptProduct", transcriptProductColumns(), $tpFile) . "\n";
+  print $sql $self->copyCommand("$schema.VariationEffect",            variationEffectColumns(),   $veFile) . "\n";
+  print $sql "COMMIT;\n";
+  close $sql;
+
+  my $connStr = "postgresql://$conn->{login}:$conn->{password}\@$conn->{host}:$conn->{port}/$conn->{dbname}";
+  my $logFile = "$dir/psql.log";
+  my $cmd = "psql -v ON_ERROR_STOP=1 --log-file='$logFile' -f '$sqlFile' '$connStr'";
+
+  $self->log("Running single-transaction load via psql");
+  my $rc = system($cmd);
+  if ($rc != 0) {
+    $self->printFile($logFile);
+    $self->error("psql load failed (rc=$rc); transaction rolled back, prior data intact");
+  }
+}
+
+sub printFile {
+  my ($self, $file) = @_;
+  return unless -e $file;
+  open(my $fh, '<', $file) or return;
+  while (<$fh>) { $self->log("psql: $_") }
+  close $fh;
+}
+
 1;

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -1,0 +1,58 @@
+package ApiCommonData::Load::Plugin::InsertVariationFeatures;
+use lib "$ENV{GUS_HOME}/lib/perl";
+@ISA = qw(GUS::PluginMgr::Plugin);
+
+use strict;
+use warnings;
+
+use GUS::PluginMgr::Plugin;
+use GUS::Supported::GusConfig;
+use ApiCommonData::Load::VariationLoader qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  transformVariationFeature transformTranscriptProduct transformVariationEffect
+/;
+use File::Temp qw/tempdir/;
+
+sub getArgsDeclaration {
+  return [
+    fileArg({ name => 'inputDir', descr => 'mergeExperiments output dir with the .dat files',
+              constraintFunc => undef, reqd => 1, isList => 0, mustExist => 1, format => 'directory' }),
+    stringArg({ name => 'extDbRlsSpec', descr => 'ExternalDatabaseRelease spec, name|version',
+                constraintFunc => undef, reqd => 1, isList => 0 }),
+    stringArg({ name => 'organismAbbrev', descr => 'apidb.organism.abbrev to scope the transcript lookup',
+                constraintFunc => undef, reqd => 1, isList => 0 }),
+    stringArg({ name => 'targetSchema', descr => 'schema to load into (default apidb; tests use jbrestel)',
+                constraintFunc => undef, reqd => 0, isList => 0, default => 'apidb' }),
+  ];
+}
+
+sub getDocumentation {
+  my $purpose = "Load mergeExperiments variationFeature.dat, transcript_product.dat, and snpeff.dat into ApiDB variation tables in a single transaction.";
+  return {
+    purpose          => $purpose,
+    purposeBrief     => $purpose,
+    notes            => "Undo via undoPreprocess (no row_alg_invocation_id on these tables).",
+    tablesAffected   => "ApiDB.VariationFeature, ApiDB.VariationTranscriptProduct, ApiDB.VariationEffect",
+    tablesDependedOn => "dots.Transcript, dots.ExternalNaSequence, apidb.Organism, sres.ExternalDatabaseRelease",
+    howToRestart     => "Re-run; the load deletes existing rows for this external_database_release_id first.",
+    failureCases     => "Unknown organismAbbrev; sequence id not in genome; transcript id unresolved for a coding effect.",
+  };
+}
+
+sub new {
+  my $class = shift;
+  my $self = {};
+  bless($self, $class);
+  $self->initialize({
+    requiredDbVersion => 4.0,
+    cvsRevision       => '$Revision$',
+    name              => ref($self),
+    argsDeclaration   => getArgsDeclaration(),
+    documentation     => getDocumentation(),
+  });
+  return $self;
+}
+
+sub run { die "not yet implemented\n"; }
+
+1;

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -58,7 +58,7 @@ sub run {
 
   my $inputDir       = $self->getArg('inputDir');
   my $organismAbbrev = $self->getArg('organismAbbrev');
-  my $schema         = $self->getArg('targetSchema');
+  my $schema         = $self->validSchema($self->getArg('targetSchema'));
   my $extDbRlsId     = $self->getExtDbRlsId($self->getArg('extDbRlsSpec'))
     or $self->error("Cannot resolve extDbRlsSpec: " . $self->getArg('extDbRlsSpec'));
 
@@ -86,10 +86,25 @@ sub transformFile {
   open(my $in,  '<', "$inputDir/$name") or $self->error("Cannot open $inputDir/$name: $!");
   open(my $out, '>', $outFile)          or $self->error("Cannot write $outFile: $!");
   my $n = eval { $transform->($in, $out) };
-  $self->error("Transform of $name failed: $@") if $@;
-  close $in; close $out;
+  my $err = $@;
+  close $in;
+  # Check close on the OUTPUT handle: a failed flush (e.g. disk full) would
+  # silently truncate the temp file, and the reported count would still be $n.
+  my $closedOk = close $out;
+  $self->error("Transform of $name failed: $err") if $err;
+  $self->error("Failed to flush/close $outFile (write may be incomplete): $!") unless $closedOk;
   $self->log("Transformed $name: $n rows");
   return $n;
+}
+
+# Guard a schema name before interpolating it into SQL. targetSchema is an
+# operator-supplied bare identifier (default 'apidb'); reject anything that
+# isn't a plain identifier so it can never carry SQL.
+sub validSchema {
+  my ($self, $schema) = @_;
+  $self->error("Invalid schema name '$schema' (expected a bare identifier)")
+    unless defined $schema && $schema =~ /^\w+$/;
+  return $schema;
 }
 
 sub getTranscriptMap {
@@ -193,15 +208,24 @@ sub loadAll {
   print $sql "COMMIT;\n";
   close $sql;
 
-  my $connStr = "postgresql://$conn->{login}:$conn->{password}\@$conn->{host}:$conn->{port}/$conn->{dbname}";
   my $logFile = "$dir/psql.log";
-  my $cmd = "psql -v ON_ERROR_STOP=1 --log-file='$logFile' -f '$sqlFile' '$connStr'";
+  # List-form system() bypasses the shell entirely: no quoting, and no way for a
+  # password or path containing shell/URI metacharacters to be misparsed. The
+  # password travels in the child's env (PGPASSWORD), never on the command line.
+  local $ENV{PGPASSWORD} = $conn->{password};
+  my @cmd = ('psql',
+             '-h', $conn->{host}, '-p', $conn->{port},
+             '-U', $conn->{login}, '-d', $conn->{dbname},
+             '-v', 'ON_ERROR_STOP=1',
+             '--log-file', $logFile,
+             '-f', $sqlFile);
 
   $self->log("Running single-transaction load via psql");
-  my $rc = system($cmd);
+  my $rc = system(@cmd);
   if ($rc != 0) {
     $self->printFile($logFile);
-    $self->error("psql load failed (rc=$rc); transaction rolled back, prior data intact");
+    my $exit = ($rc == -1) ? -1 : ($rc >> 8);   # decode wait status to exit code
+    $self->error("psql load failed (exit=$exit); transaction rolled back, prior data intact");
   }
 }
 
@@ -225,6 +249,7 @@ sub undoPreprocess {
   # targetSchema is optional; default to apidb if it was not recorded.
   my $schemas = $self->getAlgorithmParam($dbh, $rowAlgInvocationList, 'targetSchema');
   my $schema  = ($schemas && @$schemas && $schemas->[0]) ? $schemas->[0] : 'apidb';
+  $schema = $self->validSchema($schema);
 
   foreach my $spec (@$specs) {
     my ($name, $version) = split /\|/, $spec;

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -213,4 +213,54 @@ sub printFile {
   close $fh;
 }
 
+sub undoTables { return (); }   # no row_alg_invocation_id on these tables
+
+sub undoPreprocess {
+  my ($self, $dbh, $rowAlgInvocationList) = @_;
+
+  my $specs = $self->getAlgorithmParam($dbh, $rowAlgInvocationList, 'extDbRlsSpec');
+  $self->error("undo: could not recover extDbRlsSpec from core.AlgorithmParam")
+    unless $specs && @$specs;
+
+  # targetSchema is optional; default to apidb if it was not recorded.
+  my $schemas = $self->getAlgorithmParam($dbh, $rowAlgInvocationList, 'targetSchema');
+  my $schema  = ($schemas && @$schemas && $schemas->[0]) ? $schemas->[0] : 'apidb';
+
+  foreach my $spec (@$specs) {
+    my ($name, $version) = split /\|/, $spec;
+    my $sql = "
+      SELECT r.external_database_release_id
+      FROM   sres.ExternalDatabaseRelease r, sres.ExternalDatabase d
+      WHERE  d.external_database_id = r.external_database_id
+        AND  d.name = ? AND r.version = ?";
+    my $sth = $dbh->prepare($sql);
+    $sth->execute($name, $version);
+    my ($id) = $sth->fetchrow_array;
+    $self->error("undo: no external_database_release_id for '$spec'") unless $id;
+
+    my $del = $dbh->prepare("DELETE FROM $schema.VariationFeature WHERE external_database_release_id = ?");
+    my $n = $del->execute($id);
+    $self->log("undo: deleted $n VariationFeature rows (children cascade) for $spec");
+  }
+}
+
+# Recover a plugin argument's recorded value(s) from core.AlgorithmParam, keyed by
+# plugin name and invocation id. Pattern from InsertEdaStudyFromArtifacts.
+sub getAlgorithmParam {
+  my ($self, $dbh, $rowAlgInvocationList, $paramKey) = @_;
+  my $pluginName = ref($self);
+  my @values;
+  foreach my $rowAlgInvId (@$rowAlgInvocationList) {
+    my $sql = "SELECT p.STRING_VALUE
+      FROM core.ALGORITHMPARAMKEY k
+      LEFT JOIN core.ALGORITHMIMPLEMENTATION a ON k.ALGORITHM_IMPLEMENTATION_ID = a.ALGORITHM_IMPLEMENTATION_ID
+      LEFT JOIN core.ALGORITHMPARAM p ON k.ALGORITHM_PARAM_KEY_ID = p.ALGORITHM_PARAM_KEY_ID
+      WHERE a.EXECUTABLE = ? AND p.ROW_ALG_INVOCATION_ID = ? AND k.ALGORITHM_PARAM_KEY = ?";
+    my $sth = $dbh->prepare($sql);
+    $sth->execute($pluginName, $rowAlgInvId, $paramKey);
+    while (my ($v) = $sth->fetchrow_array) { push @values, $v if defined $v; }
+  }
+  return \@values;
+}
+
 1;

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -53,7 +53,44 @@ sub new {
   return $self;
 }
 
-sub run { die "not yet implemented\n"; }
+sub run {
+  my ($self) = @_;
+
+  my $inputDir       = $self->getArg('inputDir');
+  my $organismAbbrev = $self->getArg('organismAbbrev');
+  my $schema         = $self->getArg('targetSchema');
+  my $extDbRlsId     = $self->getExtDbRlsId($self->getArg('extDbRlsSpec'))
+    or $self->error("Cannot resolve extDbRlsSpec: " . $self->getArg('extDbRlsSpec'));
+
+  my $map      = $self->getTranscriptMap($organismAbbrev);
+  my $validSeq = $self->getGenomicSequenceIds($organismAbbrev);
+  $self->validateSequenceIds($inputDir, $validSeq);
+
+  my $dir = tempdir(CLEANUP => 1);
+  my ($vf, $tp, $ve) = ("$dir/vf.tmp", "$dir/tp.tmp", "$dir/ve.tmp");
+
+  my $nvf = $self->transformFile($inputDir, 'variationFeature.dat', $vf,
+    sub { transformVariationFeature($_[0], $_[1], $extDbRlsId) });
+  my $ntp = $self->transformFile($inputDir, 'transcript_product.dat', $tp,
+    sub { transformTranscriptProduct($_[0], $_[1], $map) });
+  my $nve = $self->transformFile($inputDir, 'snpeff.dat', $ve,
+    sub { transformVariationEffect($_[0], $_[1], $map) });
+
+  $self->loadAll($schema, $extDbRlsId, $vf, $tp, $ve);
+
+  return "Loaded VariationFeature=$nvf VariationTranscriptProduct=$ntp VariationEffect=$nve";
+}
+
+sub transformFile {
+  my ($self, $inputDir, $name, $outFile, $transform) = @_;
+  open(my $in,  '<', "$inputDir/$name") or $self->error("Cannot open $inputDir/$name: $!");
+  open(my $out, '>', $outFile)          or $self->error("Cannot write $outFile: $!");
+  my $n = eval { $transform->($in, $out) };
+  $self->error("Transform of $name failed: $@") if $@;
+  close $in; close $out;
+  $self->log("Transformed $name: $n rows");
+  return $n;
+}
 
 sub getTranscriptMap {
   my ($self, $organismAbbrev) = @_;

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -167,7 +167,12 @@ sub validateSequenceIds {
 # silently hits the wrong database.
 sub getPsqlConnection {
   my ($self) = @_;
-  my $cfg = GUS::Supported::GusConfig->new();
+#  my $cfg = GUS::Supported::GusConfig->new();
+  my $gusConfigFile  = $self->getArg('gusConfigFile');
+  my $cfg = $gusConfigFile
+    ? GUS::Supported::GusConfig->new($gusConfigFile)
+      : GUS::Supported::GusConfig->new();
+
   my $dsn = $cfg->getDbiDsn();     # dbi:Pg:dbname=...;host=...;port=...
   my ($dbname) = $dsn =~ /dbname=([^;]+)/;
   my ($host)   = $dsn =~ /host=([^;]+)/;

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -55,4 +55,59 @@ sub new {
 
 sub run { die "not yet implemented\n"; }
 
+sub getTranscriptMap {
+  my ($self, $organismAbbrev) = @_;
+  my $dbh = $self->getQueryHandle();
+  my $sql = "
+    SELECT t.source_id, t.na_feature_id
+    FROM   dots.Transcript t, dots.NaSequence ns, apidb.Organism o
+    WHERE  t.na_sequence_id = ns.na_sequence_id
+      AND  ns.taxon_id      = o.taxon_id
+      AND  o.abbrev         = ?";
+  my $sth = $dbh->prepare($sql);
+  $sth->execute($organismAbbrev);
+  my %map;
+  while (my ($sid, $nfid) = $sth->fetchrow_array) { $map{$sid} = $nfid; }
+  $self->error("No transcripts found for organismAbbrev '$organismAbbrev' - is it loaded?")
+    unless %map;
+  $self->log("Loaded " . scalar(keys %map) . " transcript ids for $organismAbbrev");
+  return \%map;
+}
+
+sub getGenomicSequenceIds {
+  my ($self, $organismAbbrev) = @_;
+  my $dbh = $self->getQueryHandle();
+  my $sql = "
+    SELECT ens.source_id
+    FROM   dots.ExternalNaSequence ens, apidb.Organism o
+    WHERE  ens.taxon_id = o.taxon_id
+      AND  o.abbrev     = ?";
+  my $sth = $dbh->prepare($sql);
+  $sth->execute($organismAbbrev);
+  my %seqIds;
+  while (my ($sid) = $sth->fetchrow_array) { $seqIds{$sid} = 1; }
+  return \%seqIds;
+}
+
+# Reads distinct seq_id (column 2) from variationFeature.dat and dies if any is
+# not a genomic sequence for this organism. Nothing else protects
+# VariationFeature.sequence_source_id (it is a bare VARCHAR with no FK).
+sub validateSequenceIds {
+  my ($self, $inputDir, $validSeqIds) = @_;
+  open(my $fh, '<', "$inputDir/variationFeature.dat")
+    or $self->error("Cannot open $inputDir/variationFeature.dat: $!");
+  <$fh>; # header
+  my %seen;
+  while (my $line = <$fh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    $seen{$f[1]} = 1;
+  }
+  close $fh;
+  my @bad = grep { !$validSeqIds->{$_} } sort keys %seen;
+  $self->error("variationFeature.dat references sequence ids not in this organism's genome: "
+    . join(", ", @bad)) if @bad;
+  $self->log("Validated " . scalar(keys %seen) . " distinct sequence ids");
+}
+
 1;

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -21,7 +21,7 @@ sub getArgsDeclaration {
                 constraintFunc => undef, reqd => 1, isList => 0 }),
     stringArg({ name => 'organismAbbrev', descr => 'apidb.organism.abbrev to scope the transcript lookup',
                 constraintFunc => undef, reqd => 1, isList => 0 }),
-    stringArg({ name => 'targetSchema', descr => 'schema to load into (default apidb; tests use jbrestel)',
+    stringArg({ name => 'targetSchema', descr => 'schema to load into (default apidb)',
                 constraintFunc => undef, reqd => 0, isList => 0, default => 'apidb' }),
   ];
 }

--- a/Load/plugin/perl/InsertVariationFeatures.pm
+++ b/Load/plugin/perl/InsertVariationFeatures.pm
@@ -31,7 +31,10 @@ sub getDocumentation {
   return {
     purpose          => $purpose,
     purposeBrief     => $purpose,
-    notes            => "Undo via undoPreprocess (no row_alg_invocation_id on these tables).",
+    notes            => "Undo via undoPreprocess (no row_alg_invocation_id on these tables). "
+                      . "modification_date is not loaded: the columns default to localtimestamp so "
+                      . "Postgres stamps each COPY row, which is what TuningManager reads to detect "
+                      . "that these external dependencies changed.",
     tablesAffected   => "ApiDB.VariationFeature, ApiDB.VariationTranscriptProduct, ApiDB.VariationEffect",
     tablesDependedOn => "dots.Transcript, dots.ExternalNaSequence, apidb.Organism, sres.ExternalDatabaseRelease",
     howToRestart     => "Re-run; the load deletes existing rows for this external_database_release_id first.",

--- a/Load/t/insertVariationFeatures_integration.t
+++ b/Load/t/insertVariationFeatures_integration.t
@@ -8,14 +8,24 @@ use ApiCommonData::Load::VariationLoader qw/
   transformVariationFeature transformTranscriptProduct transformVariationEffect
 /;
 
-my $INPUT = '/home/jbrestel/dnaseq_test/merge/output';
-my $DB    = 'unidb_shu_a';
+# Off by default: this test loads into a live Postgres via psql. Enable it by
+# setting VARIATION_DB_TEST=1. Connection and sample-data location are taken
+# from the environment so it is not pinned to any one developer's box.
+plan skip_all => "set VARIATION_DB_TEST=1 to run the live-DB integration test"
+  unless $ENV{VARIATION_DB_TEST};
+
+my $INPUT  = $ENV{VARIATION_TEST_INPUT} || '/home/jbrestel/dnaseq_test/merge/output';
+my $HOST   = $ENV{VARIATION_DB_HOST}    || 'localhost';
+my $PORT   = $ENV{VARIATION_DB_PORT}    || '5432';
+my $DB     = $ENV{VARIATION_DB_NAME}    || 'unidb_shu_a';
+my $SCHEMA = $ENV{VARIATION_DB_SCHEMA}  || 'jbrestel';
+my $PSQL   = "psql -h $HOST -p $PORT -d $DB";
 plan skip_all => "sample data $INPUT not present" unless -d $INPUT;
 
-# Build the transcript map from jbrestel.StubTranscript via psql.
+# Build the transcript map from <schema>.StubTranscript via psql.
 my %map;
-open(my $m, "-|", "psql -h localhost -p 5432 -d $DB -tAF'\t' -c "
-  . "'SELECT source_id, na_feature_id FROM jbrestel.stubtranscript'") or die $!;
+open(my $m, "-|", "$PSQL -tAF'\t' -c "
+  . "'SELECT source_id, na_feature_id FROM $SCHEMA.stubtranscript'") or die $!;
 while (<$m>) { chomp; my ($s,$n) = split /\t/; $map{$s} = $n if $s; }
 close $m;
 is(scalar keys %map, 78, 'stub transcript map has 78 entries');
@@ -34,26 +44,26 @@ for ([qw/variationFeature.dat vf/], [qw/transcript_product.dat tp/], [qw/snpeff.
 }
 is($n{vf}, 1504, 'vf rows'); is($n{tp}, 781, 'tp rows'); is($n{ve}, 1978, 've rows');
 
-# Assemble and run the single-transaction load into jbrestel.
+# Assemble and run the single-transaction load into <schema>.
 my $vfCols = join(", ", @{variationFeatureColumns()});
 my $tpCols = join(", ", @{transcriptProductColumns()});
 my $veCols = join(", ", @{variationEffectColumns()});
 my $sqlFile = "$dir/load.sql";
 open(my $s, '>', $sqlFile) or die $!;
 print $s "BEGIN;\n";
-print $s "DELETE FROM jbrestel.VariationFeature WHERE external_database_release_id = 1;\n";
-print $s "\\copy jbrestel.VariationFeature ($vfCols) FROM '$dir/vf.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
-print $s "\\copy jbrestel.VariationTranscriptProduct ($tpCols) FROM '$dir/tp.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
-print $s "\\copy jbrestel.VariationEffect ($veCols) FROM '$dir/ve.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
+print $s "DELETE FROM $SCHEMA.VariationFeature WHERE external_database_release_id = 1;\n";
+print $s "\\copy $SCHEMA.VariationFeature ($vfCols) FROM '$dir/vf.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
+print $s "\\copy $SCHEMA.VariationTranscriptProduct ($tpCols) FROM '$dir/tp.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
+print $s "\\copy $SCHEMA.VariationEffect ($veCols) FROM '$dir/ve.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
 print $s "COMMIT;\n";
 close $s;
 
-my $rc = system("psql -h localhost -p 5432 -d $DB -v ON_ERROR_STOP=1 -f '$sqlFile' >/dev/null 2>&1");
+my $rc = system("$PSQL -v ON_ERROR_STOP=1 -f '$sqlFile' >/dev/null 2>&1");
 is($rc, 0, 'single-transaction load succeeded');
 
 sub count1 {
   my ($tbl) = @_;
-  my $c = `psql -h localhost -p 5432 -d $DB -tAc "SELECT count(*) FROM jbrestel.$tbl"`;
+  my $c = `$PSQL -tAc "SELECT count(*) FROM $SCHEMA.$tbl"`;
   chomp $c; return $c;
 }
 is(count1('VariationFeature'), 1504, 'VariationFeature loaded');
@@ -61,12 +71,12 @@ is(count1('VariationTranscriptProduct'), 781, 'VariationTranscriptProduct loaded
 is(count1('VariationEffect'), 1978, 'VariationEffect loaded');
 
 # Intergenic rows -> NULL na_feature_id: 1978 - 1181 = 797 non-null.
-my $nn = `psql -h localhost -p 5432 -d $DB -tAc "SELECT count(na_feature_id) FROM jbrestel.VariationEffect"`;
+my $nn = `$PSQL -tAc "SELECT count(na_feature_id) FROM $SCHEMA.VariationEffect"`;
 chomp $nn;
 is($nn, 797, 'VariationEffect na_feature_id non-null count (empty -> NULL)');
 
 # Cascade delete clears all three (the undo path).
-system("psql -h localhost -p 5432 -d $DB -c 'DELETE FROM jbrestel.VariationFeature WHERE external_database_release_id = 1' >/dev/null 2>&1");
+system("$PSQL -c 'DELETE FROM $SCHEMA.VariationFeature WHERE external_database_release_id = 1' >/dev/null 2>&1");
 is(count1('VariationTranscriptProduct'), 0, 'children cascade-deleted');
 
 done_testing;

--- a/Load/t/insertVariationFeatures_integration.t
+++ b/Load/t/insertVariationFeatures_integration.t
@@ -1,0 +1,72 @@
+use strict;
+use warnings;
+use lib "$ENV{GUS_HOME}/lib/perl";
+use Test::More;
+use File::Temp qw/tempdir/;
+use ApiCommonData::Load::VariationLoader qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  transformVariationFeature transformTranscriptProduct transformVariationEffect
+/;
+
+my $INPUT = '/home/jbrestel/dnaseq_test/merge/output';
+my $DB    = 'unidb_shu_a';
+plan skip_all => "sample data $INPUT not present" unless -d $INPUT;
+
+# Build the transcript map from jbrestel.StubTranscript via psql.
+my %map;
+open(my $m, "-|", "psql -h localhost -p 5432 -d $DB -tAF'\t' -c "
+  . "'SELECT source_id, na_feature_id FROM jbrestel.stubtranscript'") or die $!;
+while (<$m>) { chomp; my ($s,$n) = split /\t/; $map{$s} = $n if $s; }
+close $m;
+is(scalar keys %map, 78, 'stub transcript map has 78 entries');
+
+my $dir = tempdir(CLEANUP => 1);
+my %n;
+for ([qw/variationFeature.dat vf/], [qw/transcript_product.dat tp/], [qw/snpeff.dat ve/]) {
+  my ($file, $tag) = @$_;
+  open(my $in, '<', "$INPUT/$file") or die $!;
+  open(my $out, '>', "$dir/$tag.tmp") or die $!;
+  $n{$tag} =
+      $tag eq 'vf' ? transformVariationFeature($in, $out, 1)
+    : $tag eq 'tp' ? transformTranscriptProduct($in, $out, \%map)
+    :                transformVariationEffect($in, $out, \%map);
+  close $in; close $out;
+}
+is($n{vf}, 1504, 'vf rows'); is($n{tp}, 781, 'tp rows'); is($n{ve}, 1978, 've rows');
+
+# Assemble and run the single-transaction load into jbrestel.
+my $vfCols = join(", ", @{variationFeatureColumns()});
+my $tpCols = join(", ", @{transcriptProductColumns()});
+my $veCols = join(", ", @{variationEffectColumns()});
+my $sqlFile = "$dir/load.sql";
+open(my $s, '>', $sqlFile) or die $!;
+print $s "BEGIN;\n";
+print $s "DELETE FROM jbrestel.VariationFeature WHERE external_database_release_id = 1;\n";
+print $s "\\copy jbrestel.VariationFeature ($vfCols) FROM '$dir/vf.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
+print $s "\\copy jbrestel.VariationTranscriptProduct ($tpCols) FROM '$dir/tp.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
+print $s "\\copy jbrestel.VariationEffect ($veCols) FROM '$dir/ve.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')\n";
+print $s "COMMIT;\n";
+close $s;
+
+my $rc = system("psql -h localhost -p 5432 -d $DB -v ON_ERROR_STOP=1 -f '$sqlFile' >/dev/null 2>&1");
+is($rc, 0, 'single-transaction load succeeded');
+
+sub count1 {
+  my ($tbl) = @_;
+  my $c = `psql -h localhost -p 5432 -d $DB -tAc "SELECT count(*) FROM jbrestel.$tbl"`;
+  chomp $c; return $c;
+}
+is(count1('VariationFeature'), 1504, 'VariationFeature loaded');
+is(count1('VariationTranscriptProduct'), 781, 'VariationTranscriptProduct loaded');
+is(count1('VariationEffect'), 1978, 'VariationEffect loaded');
+
+# Intergenic rows -> NULL na_feature_id: 1978 - 1181 = 797 non-null.
+my $nn = `psql -h localhost -p 5432 -d $DB -tAc "SELECT count(na_feature_id) FROM jbrestel.VariationEffect"`;
+chomp $nn;
+is($nn, 797, 'VariationEffect na_feature_id non-null count (empty -> NULL)');
+
+# Cascade delete clears all three (the undo path).
+system("psql -h localhost -p 5432 -d $DB -c 'DELETE FROM jbrestel.VariationFeature WHERE external_database_release_id = 1' >/dev/null 2>&1");
+is(count1('VariationTranscriptProduct'), 0, 'children cascade-deleted');
+
+done_testing;

--- a/Load/t/insertVariationFeatures_integration.t
+++ b/Load/t/insertVariationFeatures_integration.t
@@ -70,6 +70,17 @@ is(count1('VariationFeature'), 1504, 'VariationFeature loaded');
 is(count1('VariationTranscriptProduct'), 781, 'VariationTranscriptProduct loaded');
 is(count1('VariationEffect'), 1978, 'VariationEffect loaded');
 
+# modification_date is supplied by the column default, not by the copy stream, so
+# assert Postgres actually stamped every row. If this fails the stub tables in
+# $SCHEMA predate the column (apply addModificationDateToVariationTables.sql) --
+# and in a real instance it would mean TuningManager can never see these tables
+# change.
+for my $tbl (qw/VariationFeature VariationTranscriptProduct VariationEffect/) {
+  my $stale = `$PSQL -tAc "SELECT count(*) FROM $SCHEMA.$tbl WHERE modification_date IS NULL OR modification_date < localtimestamp - interval '1 hour'"`;
+  chomp $stale;
+  is($stale, 0, "$tbl modification_date stamped on every row");
+}
+
 # Intergenic rows -> NULL na_feature_id: 1978 - 1181 = 797 non-null.
 my $nn = `$PSQL -tAc "SELECT count(na_feature_id) FROM $SCHEMA.VariationEffect"`;
 chomp $nn;

--- a/Load/t/insertVariationFeatures_unit.t
+++ b/Load/t/insertVariationFeatures_unit.t
@@ -3,11 +3,9 @@ use warnings;
 use lib "$ENV{GUS_HOME}/lib/perl";
 use Test::More;
 
-# DB-free unit test of the plugin's psql \copy assembly. The load path is
-# exercised end-to-end by insertVariationFeatures_integration.t, but that test
-# constructs its own SQL; this one pins the actual copyCommand output so the two
-# cannot silently drift, and guards the single-line invariant (a multi-line
-# \copy fails in psql -f).
+# DB-free unit test of the plugin's psql \copy assembly. This pins the actual
+# copyCommand output and guards the single-line invariant (a multi-line \copy
+# fails in psql -f), plus the validSchema identifier check.
 
 require ApiCommonData::Load::Plugin::InsertVariationFeatures;
 

--- a/Load/t/insertVariationFeatures_unit.t
+++ b/Load/t/insertVariationFeatures_unit.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+use lib "$ENV{GUS_HOME}/lib/perl";
+use Test::More;
+
+# DB-free unit test of the plugin's psql \copy assembly. The load path is
+# exercised end-to-end by insertVariationFeatures_integration.t, but that test
+# constructs its own SQL; this one pins the actual copyCommand output so the two
+# cannot silently drift, and guards the single-line invariant (a multi-line
+# \copy fails in psql -f).
+
+require ApiCommonData::Load::Plugin::InsertVariationFeatures;
+
+my $pkg = 'ApiCommonData::Load::Plugin::InsertVariationFeatures';
+
+# copyCommand uses no instance state, so a bare undef invocant is fine.
+my $cmd = $pkg->can('copyCommand')->(undef, 'sch.MyTable', [qw/a b c/], '/tmp/x.tmp');
+
+unlike($cmd, qr/\n/, 'copyCommand output is a single line (required by psql -f)');
+is($cmd,
+   "\\copy sch.MyTable (a, b, c) FROM '/tmp/x.tmp' "
+   . "WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '`', ENCODING 'UTF8')",
+   'copyCommand output matches the exact \copy form the integration test uses');
+
+# validSchema rejects anything that is not a bare identifier.
+is($pkg->can('validSchema')->(undef, 'apidb'), 'apidb', 'validSchema accepts a bare identifier');
+eval { $pkg->can('validSchema')->(undef, 'apidb; drop table x') };
+ok($@, 'validSchema rejects a schema name containing SQL');
+
+done_testing;

--- a/Load/t/variationLoader.t
+++ b/Load/t/variationLoader.t
@@ -114,4 +114,40 @@ dies_ok {
   transformTranscriptProduct($r,$w,\%map);
 } 'dies on empty transcript_id (NOT NULL column)';
 
+use ApiCommonData::Load::VariationLoader qw/transformVariationEffect/;
+
+{
+  my %map = ('LmjF.01.0010:mRNA' => 9000001);
+  my $header = join("\t", qw/location seq_id allele transcript_id impact effect hgvs_c source/);
+  my $coding     = join("\t", 3745, 'LmjF.01', 'A', 'LmjF.01.0010:mRNA', 'MODERATE', 'missense_variant', 'c.958G>A', 'snpeff');
+  my $intergenic = join("\t", 233,  'LmjF.01', 'G', '',                  'MODIFIER', 'intergenic_region', 'n.233C>G', 'snpeff');
+
+  my ($inFh, $inFile)   = tempfile(UNLINK => 1);
+  my ($outFh, $outFile) = tempfile(UNLINK => 1);
+  print $inFh "$header\n$coding\n$intergenic\n"; close $inFh;
+  open(my $rh, '<', $inFile) or die $!;
+
+  my $n = transformVariationEffect($rh, $outFh, \%map);
+  close $outFh; close $rh;
+  is($n, 2, 'two rows');
+
+  open(my $oh, '<', $outFile); my @lines = <$oh>; close $oh;
+  my @c = split /\t/, $lines[0], -1;
+  is(scalar @c, 8, 'output has 8 fields');
+  is($c[0], 'LmjF.01', 'sequence_source_id first');
+  is($c[1], 3745, 'location second');
+  is($c[3], 9000001, 'coding row resolved na_feature_id');
+  my @i = split /\t/, $lines[1], -1;
+  is($i[3], '', 'intergenic row has empty na_feature_id (-> NULL)');
+}
+
+dies_ok {
+  my %map;
+  my $header = "location\tseq_id\tallele\ttranscript_id\timpact\teffect\thgvs_c\tsource";
+  my ($rh,$f)=tempfile(UNLINK=>1);
+  print $rh "$header\n1\tLmjF.01\tA\tUNKNOWN:mRNA\tHIGH\tx\tc.1A>T\tsnpeff\n"; close $rh;
+  open(my $r,'<',$f); my $j; open(my $w,'>',\$j);
+  transformVariationEffect($r,$w,\%map);
+} 'dies on non-empty unresolvable transcript_id';
+
 done_testing;

--- a/Load/t/variationLoader.t
+++ b/Load/t/variationLoader.t
@@ -69,4 +69,49 @@ dies_ok {
   ApiCommonData::Load::VariationLoader::transformVariationFeature($r, $w, 1);
 } 'dies on wrong field count';
 
+use ApiCommonData::Load::VariationLoader qw/transformTranscriptProduct/;
+
+{
+  my %map = ('LmjF.01.0010:mRNA' => 9000001);
+  my $header = "#" . join("\t", qw/seq_id location transcript_id pos_in_cds
+    pos_in_protein codon pos_in_codon count product matches_ref_codon
+    matches_ref_product downstream_of_frameshift_strain_ids hgvs_p/);
+  my $row = join("\t", 'LmjF.01', 3745, 'LmjF.01.0010:mRNA', 958, 320, 'GAC',
+    1, 3, 'D', 1, 1, '{1,3,4}', 'p.Asp320=');
+
+  my ($inFh, $inFile)   = tempfile(UNLINK => 1);
+  my ($outFh, $outFile) = tempfile(UNLINK => 1);
+  print $inFh "$header\n$row\n"; close $inFh;
+  open(my $rh, '<', $inFile) or die $!;
+
+  my $n = transformTranscriptProduct($rh, $outFh, \%map);
+  close $outFh; close $rh;
+  is($n, 1, 'one row');
+
+  open(my $oh, '<', $outFile); my $out = <$oh>; chomp $out; close $oh;
+  my @f = split /\t/, $out, -1;
+  is(scalar @f, 12, 'output has 12 fields (dropped column)');
+  is($f[2], 9000001, 'transcript_id resolved to na_feature_id');
+  is($f[7], 3, 'count value now in strain_count position');
+  is($f[-1], 'p.Asp320=', 'hgvs_p last; frameshift ids column dropped');
+}
+
+dies_ok {
+  my %map = ('LmjF.01.0010:mRNA' => 9000001);
+  my $header = "#seq_id\tlocation\ttranscript_id\tpos_in_cds\tpos_in_protein\tcodon\tpos_in_codon\tcount\tproduct\tmatches_ref_codon\tmatches_ref_product\tdownstream_of_frameshift_strain_ids\thgvs_p";
+  my ($rh,$f)=tempfile(UNLINK=>1);
+  print $rh "$header\nLmjF.01\t3745\tUNKNOWN:mRNA\t1\t1\tGAC\t1\t1\tD\t1\t1\t\tp.x\n"; close $rh;
+  open(my $r,'<',$f); my $j; open(my $w,'>',\$j);
+  transformTranscriptProduct($r,$w,\%map);
+} 'dies on unresolvable transcript_id';
+
+dies_ok {
+  my %map;
+  my $header = "#seq_id\tlocation\ttranscript_id\tpos_in_cds\tpos_in_protein\tcodon\tpos_in_codon\tcount\tproduct\tmatches_ref_codon\tmatches_ref_product\tdownstream_of_frameshift_strain_ids\thgvs_p";
+  my ($rh,$f)=tempfile(UNLINK=>1);
+  print $rh "$header\nLmjF.01\t3745\t\t1\t1\tGAC\t1\t1\tD\t1\t1\t\tp.x\n"; close $rh;
+  open(my $r,'<',$f); my $j; open(my $w,'>',\$j);
+  transformTranscriptProduct($r,$w,\%map);
+} 'dies on empty transcript_id (NOT NULL column)';
+
 done_testing;

--- a/Load/t/variationLoader.t
+++ b/Load/t/variationLoader.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use lib "$ENV{GUS_HOME}/lib/perl";
+use Test::More;
+use Test::Exception;
+use ApiCommonData::Load::VariationLoader qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  parseHeader buildSourceId
+/;
+
+# Canonical column counts match the target tables (incl. added source_id,
+# excl. dropped downstream_of_frameshift_strain_ids).
+is(scalar @{variationFeatureColumns()},   33, 'VariationFeature has 33 columns');
+is(scalar @{transcriptProductColumns()},  12, 'VariationTranscriptProduct has 12 columns');
+is(scalar @{variationEffectColumns()},      8, 'VariationEffect has 8 columns');
+
+is(variationFeatureColumns()->[0], 'source_id',          'source_id first');
+is(variationFeatureColumns()->[1], 'sequence_source_id', 'sequence_source_id second');
+
+# parseHeader strips a leading # and splits on tab.
+is_deeply(parseHeader("#a\tb\tc"), [qw/a b c/], 'parseHeader strips leading #');
+is_deeply(parseHeader("a\tb\tc"),  [qw/a b c/], 'parseHeader without #');
+
+is(buildSourceId('LmjF.01', 233), 'Variant_LmjF.01_233', 'buildSourceId format');
+
+done_testing;

--- a/Load/t/variationLoader.t
+++ b/Load/t/variationLoader.t
@@ -23,4 +23,50 @@ is_deeply(parseHeader("a\tb\tc"),  [qw/a b c/], 'parseHeader without #');
 
 is(buildSourceId('LmjF.01', 233), 'Variant_LmjF.01_233', 'buildSourceId format');
 
+use File::Temp qw/tempfile/;
+use ApiCommonData::Load::VariationLoader qw/transformVariationFeature/;
+
+{
+  my $header = join("\t", qw/location seq_id reference_strain is_coding variant_type
+    distinct_strain_count called_strain_count no_call_strain_count call_rate
+    total_ploidy_count ref_allele_frequency het_strain_count
+    snp_ref_allele snp_major_allele snp_major_allele_frequency snp_major_allele_strain_count
+    snp_minor_allele snp_minor_allele_frequency snp_minor_allele_strain_count
+    snp_major_genomic_hgvs snp_minor_genomic_hgvs
+    indel_ref_allele indel_major_allele indel_major_allele_frequency indel_major_allele_strain_count
+    indel_minor_allele indel_minor_allele_frequency indel_minor_allele_strain_count
+    indel_major_genomic_hgvs indel_minor_genomic_hgvs indel_frame_effect/);
+  # 233 SNV row with empty indel_* fields
+  my @vals = (233, 'LmjF.01', 'lmajFriedlin', 0, 'SNV',
+    5,4,0,'1.0000',9,'0.7778',0, 'C','G','0.2222',1,'','','', 'LmjF.01:g.233C>G','',
+    '','','',  '','','',  '','','', '');
+  my $row = join("\t", @vals);
+
+  my ($inFh, $inFile)   = tempfile(UNLINK => 1);
+  my ($outFh, $outFile) = tempfile(UNLINK => 1);
+  print $inFh "$header\n$row\n"; close $inFh;
+  open(my $rh, '<', $inFile) or die $!;
+
+  my $n = transformVariationFeature($rh, $outFh, 42);
+  close $outFh; close $rh;
+  is($n, 1, 'one data row transformed');
+
+  open(my $oh, '<', $outFile) or die $!;
+  my $out = <$oh>; chomp $out; close $oh;
+  my @f = split /\t/, $out, -1;
+  is(scalar @f, 33, 'output has 33 fields');
+  is($f[0], 'Variant_LmjF.01_233', 'source_id prepended');
+  is($f[1], 'LmjF.01', 'sequence_source_id = seq_id');
+  is($f[2], 233, 'location third');
+  is($f[-1], 42, 'external_database_release_id appended');
+}
+
+dies_ok {
+  my ($rh, $f) = tempfile(UNLINK => 1);
+  print $rh "location\tseq_id\n1\t2\t3\n"; close $rh;
+  open(my $r, '<', $f); my $junk;
+  open(my $w, '>', \$junk);
+  ApiCommonData::Load::VariationLoader::transformVariationFeature($r, $w, 1);
+} 'dies on wrong field count';
+
 done_testing;

--- a/Load/t/variationLoader.t
+++ b/Load/t/variationLoader.t
@@ -150,4 +150,69 @@ dies_ok {
   transformVariationEffect($r,$w,\%map);
 } 'dies on non-empty unresolvable transcript_id';
 
+# --- Full-row column-mapping assertions --------------------------------------
+# These guard the lockstep between the *Columns() lists and the transform bodies.
+# A count-preserving column reorder would pass the count checks above but corrupt
+# this exact-output check. Each input column carries a distinct sentinel value so
+# any misplacement is visible.
+
+sub run_transform {
+  my ($fn, $header, $row, @extra) = @_;
+  my ($in, $inF)  = tempfile(UNLINK => 1);
+  my ($out, $outF) = tempfile(UNLINK => 1);
+  print $in "$header\n$row\n"; close $in;
+  open(my $rh, '<', $inF) or die $!;
+  $fn->($rh, $out, @extra);
+  close $out; close $rh;
+  open(my $oh, '<', $outF) or die $!;
+  my $line = <$oh>; close $oh; chomp $line;
+  return [ split /\t/, $line, -1 ];
+}
+
+{
+  # variationFeature: 31 in -> 33 out. Distinct values c2..c30 for the pass-through columns.
+  my @in = ('100', 'SEQ');
+  push @in, "c$_" for (2..30);
+  is(scalar @in, 31, 'vf full-row: input has 31 fields');
+  my $header = join("\t", qw/location seq_id reference_strain is_coding variant_type
+    distinct_strain_count called_strain_count no_call_strain_count call_rate
+    total_ploidy_count ref_allele_frequency het_strain_count
+    snp_ref_allele snp_major_allele snp_major_allele_frequency snp_major_allele_strain_count
+    snp_minor_allele snp_minor_allele_frequency snp_minor_allele_strain_count
+    snp_major_genomic_hgvs snp_minor_genomic_hgvs
+    indel_ref_allele indel_major_allele indel_major_allele_frequency indel_major_allele_strain_count
+    indel_minor_allele indel_minor_allele_frequency indel_minor_allele_strain_count
+    indel_major_genomic_hgvs indel_minor_genomic_hgvs indel_frame_effect/);
+  my $got = run_transform(\&transformVariationFeature, $header, join("\t", @in), 77);
+  my @expect = ('Variant_SEQ_100', 'SEQ', '100');
+  push @expect, "c$_" for (2..30);
+  push @expect, '77';
+  is_deeply($got, \@expect, 'vf full-row maps every column to the right position');
+}
+
+{
+  # transcriptProduct: 13 in -> 12 out. transcript_id 'T'->555; col 11 dropped.
+  my %map = ('T' => 555);
+  my $header = "#" . join("\t", qw/seq_id location transcript_id pos_in_cds
+    pos_in_protein codon pos_in_codon count product matches_ref_codon
+    matches_ref_product downstream_of_frameshift_strain_ids hgvs_p/);
+  my @in = ('SEQ','100','T','pc','pp','COD','pcod','CNT','PROD','mrc','mrp','DROPME','HP');
+  is(scalar @in, 13, 'tp full-row: input has 13 fields');
+  my $got = run_transform(\&transformTranscriptProduct, $header, join("\t", @in), \%map);
+  is_deeply($got,
+    ['SEQ','100',555,'pc','pp','COD','pcod','CNT','PROD','mrc','mrp','HP'],
+    'tp full-row: na_feature_id resolved, frameshift column dropped, count->strain_count');
+}
+
+{
+  # variationEffect: 8 in -> 8 out, reordered. transcript_id 'T'->555.
+  my %map = ('T' => 555);
+  my $header = join("\t", qw/location seq_id allele transcript_id impact effect hgvs_c source/);
+  my @in = ('100','SEQ','AL','T','IMP','EFF','HC','SRC');
+  my $got = run_transform(\&transformVariationEffect, $header, join("\t", @in), \%map);
+  is_deeply($got,
+    ['SEQ','100','AL',555,'IMP','EFF','HC','SRC'],
+    've full-row: reordered to sequence_source_id, location, allele, na_feature_id, ...');
+}
+
 done_testing;

--- a/docs/superpowers/plans/2026-07-10-variation-dat-loader.md
+++ b/docs/superpowers/plans/2026-07-10-variation-dat-loader.md
@@ -1,0 +1,1135 @@
+# Variation `.dat` Loader Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Load `mergeExperiments` `variationFeature.dat`, `transcript_product.dat`, and `snpeff.dat` into `ApiDB.VariationFeature`, `VariationTranscriptProduct`, and `VariationEffect` via a GUS plugin that transforms each file and loads all three in a single psql transaction.
+
+**Architecture:** Split responsibilities. `ApiCommonData::Load::VariationLoader` is a pure module (no GUS, no DBI) that owns the canonical column orders and the three file transforms — it is unit-testable without a database. `ApiCommonData::Load::Plugin::InsertVariationFeatures` is the GUS plugin that resolves the external database release, builds the organism-scoped transcript map from the database, validates sequence ids, calls the transform, assembles one SQL script (`BEGIN; DELETE; \copy ×3; COMMIT;`), and runs `psql -f` once. Undo is via the undocumented `undoPreprocess` hook (`undoTables` cannot work — no `row_alg_invocation_id`).
+
+**Tech Stack:** Perl 5, GUS PluginMgr, PostgreSQL `\copy` via the `psql` CLI, `Test::More`/`Test::Exception`/`prove`.
+
+**Design spec:** `docs/superpowers/specs/2026-07-10-variation-dat-loader-design.md` — read it first.
+
+---
+
+## Preconditions (verified 2026-07-10, do not re-derive)
+
+- Sample data: `/home/jbrestel/dnaseq_test/merge/output` (*L. major*, 1504 / 781 / 1978 rows).
+- Test DB `unidb_shu_a` on **localhost:5432** contains *A. fumigatus* etc., **no *L. major***.
+- Stub test env already built in `unidb_shu_a`: schema `jbrestel` holds the three tables
+  (with `source_id`, without `downstream_of_frameshift_strain_ids`, external FKs dropped,
+  parent→child `ON DELETE CASCADE` kept) plus `jbrestel.StubTranscript` (78 `LmjF`
+  transcripts → synthetic `na_feature_id` 9000001+). Recreate with the scratchpad SQL if lost.
+- **`psql \copy` must be one line** in a `-f` script; multi-line fails with `parse error at end of line`.
+  `Psql.pm`'s `getCommand()` emits multi-line and is therefore NOT reusable here — build the
+  `\copy` line directly.
+- `ON_ERROR_STOP=1` aborts the whole script (and rolls back the open transaction) when any
+  `\copy` fails. Verified.
+- Empty field under `FORMAT CSV` → NULL. This is the pipeline's "absent" convention.
+- The plugin's own `gus.config` `dbiDsn` uses **port 5433** and DB `genomicsdb_069n`; the test
+  DB is a different port/DB. Always pass host/port/dbname explicitly to `psql`.
+
+## Environment setup (run once per shell before building or running)
+
+```bash
+export PROJECT_HOME=/home/jbrestel/workspaces/dataLoad/project_home
+export GUS_HOME=/home/jbrestel/workspaces/dataLoad/gus_home
+export PATH=$GUS_HOME/bin:$PATH
+export PERL5LIB=$GUS_HOME/lib/perl
+```
+
+`GUS_HOME` holds **copies** of source, not symlinks. After editing any `.pm` under
+`$PROJECT_HOME/ApiCommonData`, reinstall before running the plugin:
+
+```bash
+$PROJECT_HOME/install/bin/build ApiCommonData -append
+```
+
+Unit tests (Task 2–5) run directly from `$PROJECT_HOME` without a build and without a DB.
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `ApidbSchema` repo `.../Postgres/createVariationTables.sql` | Add `VariationFeature.source_id`; drop `VariationTranscriptProduct.downstream_of_frameshift_strain_ids` |
+| `ApiCommonData/Load/lib/perl/VariationLoader.pm` | Pure: canonical column orders + 3 transforms. No GUS/DBI. |
+| `ApiCommonData/Load/t/variationLoader.t` | Unit tests for the above. No DB. |
+| `ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm` | GUS plugin: DB queries, psql orchestration, undo. |
+| `ApiCommonData/Load/t/insertVariationFeatures_integration.t` | Integration test against `jbrestel` stub schema. |
+
+---
+
+## Task 1: Schema changes in ApidbSchema
+
+**Repo:** `/home/jbrestel/workspaces/misc/ApidbSchema`, branch `dnaseq-tables` (already checked out).
+**File:** `Main/lib/sql/apidbschema/Postgres/createVariationTables.sql`
+
+- [ ] **Step 1: Add `source_id` as the first column of `ApiDB.VariationFeature`**
+
+Insert as the new first column in the `CREATE TABLE ApiDB.VariationFeature` block:
+
+```sql
+  source_id                       VARCHAR(100)  NOT NULL,
+```
+
+- [ ] **Step 2: Add a UNIQUE constraint on `source_id`**
+
+After the existing `PRIMARY KEY (sequence_source_id, location)` line, add:
+
+```sql
+  , UNIQUE (source_id)
+```
+
+- [ ] **Step 3: Drop `downstream_of_frameshift_strain_ids` from `ApiDB.VariationTranscriptProduct`**
+
+Delete this line from the `CREATE TABLE ApiDB.VariationTranscriptProduct` block:
+
+```sql
+  downstream_of_frameshift_strain_ids VARCHAR(4000),
+```
+
+- [ ] **Step 4: Verify the DDL parses against a scratch schema**
+
+```bash
+psql -h localhost -p 5432 -d unidb_shu_a -v ON_ERROR_STOP=1 <<'SQL'
+BEGIN;
+CREATE SCHEMA _ddlcheck;
+SET search_path TO _ddlcheck;
+-- paste the three CREATE TABLE statements with ApiDB. -> _ddlcheck. and
+-- FKs to sres/dots removed, to confirm column syntax only
+ROLLBACK;
+SQL
+```
+Expected: no syntax error. (This checks column syntax; the real FKs need the real schemas.)
+
+- [ ] **Step 5: Commit (ApidbSchema repo)**
+
+```bash
+cd /home/jbrestel/workspaces/misc/ApidbSchema
+git add Main/lib/sql/apidbschema/Postgres/createVariationTables.sql
+git commit -m "feat: add VariationFeature.source_id UNIQUE; drop downstream_of_frameshift_strain_ids
+
+source_id = Variant_<sequence_source_id>_<location>, a stable opaque identifier.
+downstream_of_frameshift_strain_ids referenced unloaded sample.dat; kept in the
+.dat file for QA only.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: VariationLoader — column definitions and header parsing
+
+**Files:**
+- Create: `ApiCommonData/Load/lib/perl/VariationLoader.pm`
+- Test: `ApiCommonData/Load/t/variationLoader.t`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `ApiCommonData/Load/t/variationLoader.t`:
+
+```perl
+use strict;
+use warnings;
+use lib "$ENV{PROJECT_HOME}/ApiCommonData/Load/lib/perl";
+use Test::More;
+use Test::Exception;
+use ApiCommonData::Load::VariationLoader qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  parseHeader buildSourceId
+/;
+
+# Canonical column counts match the target tables (incl. added source_id,
+# excl. dropped downstream_of_frameshift_strain_ids).
+is(scalar @{variationFeatureColumns()},   33, 'VariationFeature has 33 columns');
+is(scalar @{transcriptProductColumns()},  12, 'VariationTranscriptProduct has 12 columns');
+is(scalar @{variationEffectColumns()},      8, 'VariationEffect has 8 columns');
+
+is(variationFeatureColumns()->[0], 'source_id',          'source_id first');
+is(variationFeatureColumns()->[1], 'sequence_source_id', 'sequence_source_id second');
+
+# parseHeader strips a leading # and splits on tab.
+is_deeply(parseHeader("#a\tb\tc"), [qw/a b c/], 'parseHeader strips leading #');
+is_deeply(parseHeader("a\tb\tc"),  [qw/a b c/], 'parseHeader without #');
+
+is(buildSourceId('LmjF.01', 233), 'Variant_LmjF.01_233', 'buildSourceId format');
+
+done_testing;
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: FAIL — `Can't locate ApiCommonData/Load/VariationLoader.pm`.
+
+- [ ] **Step 3: Write the minimal module**
+
+Create `ApiCommonData/Load/lib/perl/VariationLoader.pm`:
+
+```perl
+package ApiCommonData::Load::VariationLoader;
+
+use strict;
+use warnings;
+
+use Exporter 'import';
+our @EXPORT_OK = qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  parseHeader buildSourceId
+  transformVariationFeature transformTranscriptProduct transformVariationEffect
+/;
+
+# Canonical output column order. The transforms below emit values in exactly
+# this order; the plugin uses these same lists to build each \copy field list.
+# Keep the two in lockstep — the unit tests assert the counts match.
+
+sub variationFeatureColumns {
+  return [ qw/
+    source_id sequence_source_id location reference_strain is_coding variant_type
+    distinct_strain_count called_strain_count no_call_strain_count call_rate
+    total_ploidy_count ref_allele_frequency het_strain_count
+    snp_ref_allele snp_major_allele snp_major_allele_frequency snp_major_allele_strain_count
+    snp_minor_allele snp_minor_allele_frequency snp_minor_allele_strain_count
+    snp_major_genomic_hgvs snp_minor_genomic_hgvs
+    indel_ref_allele indel_major_allele indel_major_allele_frequency indel_major_allele_strain_count
+    indel_minor_allele indel_minor_allele_frequency indel_minor_allele_strain_count
+    indel_major_genomic_hgvs indel_minor_genomic_hgvs indel_frame_effect
+    external_database_release_id
+  / ];
+}
+
+sub transcriptProductColumns {
+  return [ qw/
+    sequence_source_id location na_feature_id pos_in_cds pos_in_protein codon
+    pos_in_codon strain_count product matches_ref_codon matches_ref_product hgvs_p
+  / ];
+}
+
+sub variationEffectColumns {
+  return [ qw/
+    sequence_source_id location allele na_feature_id impact effect hgvs_c source
+  / ];
+}
+
+sub parseHeader {
+  my ($line) = @_;
+  chomp $line;
+  $line =~ s/^#//;
+  return [ split /\t/, $line, -1 ];
+}
+
+sub buildSourceId {
+  my ($seq, $loc) = @_;
+  return "Variant_${seq}_${loc}";
+}
+
+1;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: PASS, 8 subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/lib/perl/VariationLoader.pm Load/t/variationLoader.t
+git commit -m "feat: VariationLoader column defs + header/source_id helpers
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: VariationLoader — variationFeature transform
+
+**Files:**
+- Modify: `ApiCommonData/Load/lib/perl/VariationLoader.pm`
+- Test: `ApiCommonData/Load/t/variationLoader.t`
+
+Input columns (31): `location, seq_id, reference_strain, is_coding, variant_type, distinct_strain_count, called_strain_count, no_call_strain_count, call_rate, total_ploidy_count, ref_allele_frequency, het_strain_count, snp_ref_allele, snp_major_allele, snp_major_allele_frequency, snp_major_allele_strain_count, snp_minor_allele, snp_minor_allele_frequency, snp_minor_allele_strain_count, snp_major_genomic_hgvs, snp_minor_genomic_hgvs, indel_ref_allele, indel_major_allele, indel_major_allele_frequency, indel_major_allele_strain_count, indel_minor_allele, indel_minor_allele_frequency, indel_minor_allele_strain_count, indel_major_genomic_hgvs, indel_minor_genomic_hgvs, indel_frame_effect`.
+
+Transform: prepend `source_id`, emit `seq_id` before `location`, append `external_database_release_id`.
+
+- [ ] **Step 1: Write the failing test** (append to `variationLoader.t`, before `done_testing`)
+
+```perl
+use File::Temp qw/tempfile/;
+use ApiCommonData::Load::VariationLoader qw/transformVariationFeature/;
+
+{
+  my $header = join("\t", qw/location seq_id reference_strain is_coding variant_type
+    distinct_strain_count called_strain_count no_call_strain_count call_rate
+    total_ploidy_count ref_allele_frequency het_strain_count
+    snp_ref_allele snp_major_allele snp_major_allele_frequency snp_major_allele_strain_count
+    snp_minor_allele snp_minor_allele_frequency snp_minor_allele_strain_count
+    snp_major_genomic_hgvs snp_minor_genomic_hgvs
+    indel_ref_allele indel_major_allele indel_major_allele_frequency indel_major_allele_strain_count
+    indel_minor_allele indel_minor_allele_frequency indel_minor_allele_strain_count
+    indel_major_genomic_hgvs indel_minor_genomic_hgvs indel_frame_effect/);
+  # 233 SNV row with empty indel_* fields
+  my @vals = (233, 'LmjF.01', 'lmajFriedlin', 0, 'SNV',
+    5,4,0,'1.0000',9,'0.7778',0, 'C','G','0.2222',1,'','','', 'LmjF.01:g.233C>G','',
+    '','','',  '','','',  '','','');
+  my $row = join("\t", @vals);
+
+  my ($inFh, $inFile)   = tempfile(UNLINK => 1);
+  my ($outFh, $outFile) = tempfile(UNLINK => 1);
+  print $inFh "$header\n$row\n"; close $inFh;
+  open(my $rh, '<', $inFile) or die $!;
+
+  my $n = transformVariationFeature($rh, $outFh, 42);
+  close $outFh; close $rh;
+  is($n, 1, 'one data row transformed');
+
+  open(my $oh, '<', $outFile) or die $!;
+  my $out = <$oh>; chomp $out; close $oh;
+  my @f = split /\t/, $out, -1;
+  is(scalar @f, 33, 'output has 33 fields');
+  is($f[0], 'Variant_LmjF.01_233', 'source_id prepended');
+  is($f[1], 'LmjF.01', 'sequence_source_id = seq_id');
+  is($f[2], 233, 'location third');
+  is($f[-1], 42, 'external_database_release_id appended');
+}
+
+dies_ok {
+  my ($rh, $f) = tempfile(UNLINK => 1);
+  print $rh "location\tseq_id\n1\t2\t3\n"; close $rh;
+  open(my $r, '<', $f); my $junk;
+  open(my $w, '>', \$junk);
+  ApiCommonData::Load::VariationLoader::transformVariationFeature($r, $w, 1);
+} 'dies on wrong field count';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: FAIL — `transformVariationFeature` undefined.
+
+- [ ] **Step 3: Implement** (add to `VariationLoader.pm` before the final `1;`)
+
+```perl
+sub transformVariationFeature {
+  my ($inFh, $outFh, $extDbRlsId) = @_;
+  my $header = <$inFh>;
+  die "variationFeature.dat: empty file\n" unless defined $header;
+  my $cols = parseHeader($header);
+  die "variationFeature.dat: expected 31 columns, got " . scalar(@$cols) . "\n"
+    unless @$cols == 31;
+  die "variationFeature.dat: unexpected header (want location, seq_id first)\n"
+    unless $cols->[0] eq 'location' && $cols->[1] eq 'seq_id';
+
+  my $n = 0;
+  while (my $line = <$inFh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    die "variationFeature.dat line $.: expected 31 fields, got " . scalar(@f) . "\n"
+      unless @f == 31;
+    my ($loc, $seq) = @f[0, 1];
+    print $outFh join("\t", buildSourceId($seq, $loc), $seq, $loc, @f[2..30], $extDbRlsId), "\n";
+    $n++;
+  }
+  return $n;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/lib/perl/VariationLoader.pm Load/t/variationLoader.t
+git commit -m "feat: transformVariationFeature
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: VariationLoader — transcriptProduct transform
+
+**Files:**
+- Modify: `ApiCommonData/Load/lib/perl/VariationLoader.pm`
+- Test: `ApiCommonData/Load/t/variationLoader.t`
+
+Input columns (13): `seq_id, location, transcript_id, pos_in_cds, pos_in_protein, codon, pos_in_codon, count, product, matches_ref_codon, matches_ref_product, downstream_of_frameshift_strain_ids, hgvs_p` (header prefixed with `#`).
+Transform: resolve `transcript_id` → `na_feature_id` (fatal on empty or miss), rename `count` → `strain_count` positionally, DROP column 12 (`downstream_of_frameshift_strain_ids`).
+
+- [ ] **Step 1: Write the failing test** (append before `done_testing`)
+
+```perl
+use ApiCommonData::Load::VariationLoader qw/transformTranscriptProduct/;
+
+{
+  my %map = ('LmjF.01.0010:mRNA' => 9000001);
+  my $header = "#" . join("\t", qw/seq_id location transcript_id pos_in_cds
+    pos_in_protein codon pos_in_codon count product matches_ref_codon
+    matches_ref_product downstream_of_frameshift_strain_ids hgvs_p/);
+  my $row = join("\t", 'LmjF.01', 3745, 'LmjF.01.0010:mRNA', 958, 320, 'GAC',
+    1, 3, 'D', 1, 1, '{1,3,4}', 'p.Asp320=');
+
+  my ($inFh, $inFile)   = tempfile(UNLINK => 1);
+  my ($outFh, $outFile) = tempfile(UNLINK => 1);
+  print $inFh "$header\n$row\n"; close $inFh;
+  open(my $rh, '<', $inFile) or die $!;
+
+  my $n = transformTranscriptProduct($rh, $outFh, \%map);
+  close $outFh; close $rh;
+  is($n, 1, 'one row');
+
+  open(my $oh, '<', $outFile); my $out = <$oh>; chomp $out; close $oh;
+  my @f = split /\t/, $out, -1;
+  is(scalar @f, 12, 'output has 12 fields (dropped column)');
+  is($f[2], 9000001, 'transcript_id resolved to na_feature_id');
+  is($f[7], 3, 'count value now in strain_count position');
+  is($f[-1], 'p.Asp320=', 'hgvs_p last; frameshift ids column dropped');
+}
+
+dies_ok {
+  my %map = ('LmjF.01.0010:mRNA' => 9000001);
+  my $header = "#seq_id\tlocation\ttranscript_id\tpos_in_cds\tpos_in_protein\tcodon\tpos_in_codon\tcount\tproduct\tmatches_ref_codon\tmatches_ref_product\tdownstream_of_frameshift_strain_ids\thgvs_p";
+  my ($rh,$f)=tempfile(UNLINK=>1);
+  print $rh "$header\nLmjF.01\t3745\tUNKNOWN:mRNA\t1\t1\tGAC\t1\t1\tD\t1\t1\t\tp.x\n"; close $rh;
+  open(my $r,'<',$f); my $j; open(my $w,'>',\$j);
+  transformTranscriptProduct($r,$w,\%map);
+} 'dies on unresolvable transcript_id';
+
+dies_ok {
+  my %map;
+  my $header = "#seq_id\tlocation\ttranscript_id\tpos_in_cds\tpos_in_protein\tcodon\tpos_in_codon\tcount\tproduct\tmatches_ref_codon\tmatches_ref_product\tdownstream_of_frameshift_strain_ids\thgvs_p";
+  my ($rh,$f)=tempfile(UNLINK=>1);
+  print $rh "$header\nLmjF.01\t3745\t\t1\t1\tGAC\t1\t1\tD\t1\t1\t\tp.x\n"; close $rh;
+  open(my $r,'<',$f); my $j; open(my $w,'>',\$j);
+  transformTranscriptProduct($r,$w,\%map);
+} 'dies on empty transcript_id (NOT NULL column)';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: FAIL — `transformTranscriptProduct` undefined.
+
+- [ ] **Step 3: Implement** (add before final `1;`)
+
+```perl
+sub transformTranscriptProduct {
+  my ($inFh, $outFh, $map) = @_;
+  my $header = <$inFh>;
+  die "transcript_product.dat: empty file\n" unless defined $header;
+  my $cols = parseHeader($header);
+  die "transcript_product.dat: expected 13 columns, got " . scalar(@$cols) . "\n"
+    unless @$cols == 13;
+  die "transcript_product.dat: unexpected header (want seq_id first)\n"
+    unless $cols->[0] eq 'seq_id';
+
+  my $n = 0;
+  while (my $line = <$inFh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    die "transcript_product.dat line $.: expected 13 fields, got " . scalar(@f) . "\n"
+      unless @f == 13;
+    my $tid = $f[2];
+    die "transcript_product.dat line $.: empty transcript_id (na_feature_id is NOT NULL)\n"
+      if $tid eq '';
+    my $nfid = $map->{$tid};
+    die "transcript_product.dat line $.: transcript_id '$tid' not found for this organism\n"
+      unless defined $nfid;
+    # out: seq_id, location, na_feature_id, cols 4..11 (pos_in_cds..matches_ref_product), hgvs_p
+    # drop col index 11 (downstream_of_frameshift_strain_ids); hgvs_p is index 12
+    print $outFh join("\t", @f[0,1], $nfid, @f[3..10], $f[12]), "\n";
+    $n++;
+  }
+  return $n;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/lib/perl/VariationLoader.pm Load/t/variationLoader.t
+git commit -m "feat: transformTranscriptProduct (resolve na_feature_id, drop col, rename count)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: VariationLoader — variationEffect transform
+
+**Files:**
+- Modify: `ApiCommonData/Load/lib/perl/VariationLoader.pm`
+- Test: `ApiCommonData/Load/t/variationLoader.t`
+
+Input columns (8): `location, seq_id, allele, transcript_id, impact, effect, hgvs_c, source`.
+Transform: reorder to `sequence_source_id, location, allele, na_feature_id, impact, effect, hgvs_c, source`. Resolve `transcript_id` → `na_feature_id`; **empty transcript_id → empty output (NULL)**; **non-empty but not found → fatal**.
+
+- [ ] **Step 1: Write the failing test** (append before `done_testing`)
+
+```perl
+use ApiCommonData::Load::VariationLoader qw/transformVariationEffect/;
+
+{
+  my %map = ('LmjF.01.0010:mRNA' => 9000001);
+  my $header = join("\t", qw/location seq_id allele transcript_id impact effect hgvs_c source/);
+  my $coding     = join("\t", 3745, 'LmjF.01', 'A', 'LmjF.01.0010:mRNA', 'MODERATE', 'missense_variant', 'c.958G>A', 'snpeff');
+  my $intergenic = join("\t", 233,  'LmjF.01', 'G', '',                  'MODIFIER', 'intergenic_region', 'n.233C>G', 'snpeff');
+
+  my ($inFh, $inFile)   = tempfile(UNLINK => 1);
+  my ($outFh, $outFile) = tempfile(UNLINK => 1);
+  print $inFh "$header\n$coding\n$intergenic\n"; close $inFh;
+  open(my $rh, '<', $inFile) or die $!;
+
+  my $n = transformVariationEffect($rh, $outFh, \%map);
+  close $outFh; close $rh;
+  is($n, 2, 'two rows');
+
+  open(my $oh, '<', $outFile); my @lines = <$oh>; close $oh;
+  my @c = split /\t/, $lines[0], -1;
+  is(scalar @c, 8, 'output has 8 fields');
+  is($c[0], 'LmjF.01', 'sequence_source_id first');
+  is($c[1], 3745, 'location second');
+  is($c[3], 9000001, 'coding row resolved na_feature_id');
+  my @i = split /\t/, $lines[1], -1;
+  is($i[3], '', 'intergenic row has empty na_feature_id (-> NULL)');
+}
+
+dies_ok {
+  my %map;
+  my $header = "location\tseq_id\tallele\ttranscript_id\timpact\teffect\thgvs_c\tsource";
+  my ($rh,$f)=tempfile(UNLINK=>1);
+  print $rh "$header\n1\tLmjF.01\tA\tUNKNOWN:mRNA\tHIGH\tx\tc.1A>T\tsnpeff\n"; close $rh;
+  open(my $r,'<',$f); my $j; open(my $w,'>',\$j);
+  transformVariationEffect($r,$w,\%map);
+} 'dies on non-empty unresolvable transcript_id';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: FAIL — `transformVariationEffect` undefined.
+
+- [ ] **Step 3: Implement** (add before final `1;`)
+
+```perl
+sub transformVariationEffect {
+  my ($inFh, $outFh, $map) = @_;
+  my $header = <$inFh>;
+  die "snpeff.dat: empty file\n" unless defined $header;
+  my $cols = parseHeader($header);
+  die "snpeff.dat: expected 8 columns, got " . scalar(@$cols) . "\n"
+    unless @$cols == 8;
+  die "snpeff.dat: unexpected header (want location first)\n"
+    unless $cols->[0] eq 'location';
+
+  my $n = 0;
+  while (my $line = <$inFh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    die "snpeff.dat line $.: expected 8 fields, got " . scalar(@f) . "\n"
+      unless @f == 8;
+    my ($loc, $seq, $allele, $tid, $impact, $effect, $hgvsc, $source) = @f;
+    my $nfid = '';                       # empty -> NULL for intergenic
+    if ($tid ne '') {
+      $nfid = $map->{$tid};
+      die "snpeff.dat line $.: transcript_id '$tid' not found for this organism\n"
+        unless defined $nfid;
+    }
+    print $outFh join("\t", $seq, $loc, $allele, $nfid, $impact, $effect, $hgvsc, $source), "\n";
+    $n++;
+  }
+  return $n;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/variationLoader.t`
+Expected: PASS, all subtests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/lib/perl/VariationLoader.pm Load/t/variationLoader.t
+git commit -m "feat: transformVariationEffect (reorder, empty transcript_id -> NULL)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Plugin skeleton — args, documentation, new()
+
+**File:** Create `ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm`
+
+- [ ] **Step 1: Write the skeleton**
+
+```perl
+package ApiCommonData::Load::Plugin::InsertVariationFeatures;
+use lib "$ENV{GUS_HOME}/lib/perl";
+@ISA = qw(GUS::PluginMgr::Plugin);
+
+use strict;
+use warnings;
+
+use GUS::PluginMgr::Plugin;
+use GUS::Supported::GusConfig;
+use ApiCommonData::Load::VariationLoader qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  transformVariationFeature transformTranscriptProduct transformVariationEffect
+/;
+use File::Temp qw/tempdir/;
+
+sub getArgsDeclaration {
+  return [
+    fileArg({ name => 'inputDir', descr => 'mergeExperiments output dir with the .dat files',
+              constraintFunc => undef, reqd => 1, isList => 0, mustExist => 1, format => 'directory' }),
+    stringArg({ name => 'extDbRlsSpec', descr => 'ExternalDatabaseRelease spec, name|version',
+                constraintFunc => undef, reqd => 1, isList => 0 }),
+    stringArg({ name => 'organismAbbrev', descr => 'apidb.organism.abbrev to scope the transcript lookup',
+                constraintFunc => undef, reqd => 1, isList => 0 }),
+    stringArg({ name => 'targetSchema', descr => 'schema to load into (default apidb; tests use jbrestel)',
+                constraintFunc => undef, reqd => 0, isList => 0, default => 'apidb' }),
+  ];
+}
+
+sub getDocumentation {
+  my $purpose = "Load mergeExperiments variationFeature.dat, transcript_product.dat, and snpeff.dat into ApiDB variation tables in a single transaction.";
+  return {
+    purpose          => $purpose,
+    purposeBrief     => $purpose,
+    notes            => "Undo via undoPreprocess (no row_alg_invocation_id on these tables).",
+    tablesAffected   => "ApiDB.VariationFeature, ApiDB.VariationTranscriptProduct, ApiDB.VariationEffect",
+    tablesDependedOn => "dots.Transcript, dots.ExternalNaSequence, apidb.Organism, sres.ExternalDatabaseRelease",
+    howToRestart     => "Re-run; the load deletes existing rows for this external_database_release_id first.",
+    failureCases     => "Unknown organismAbbrev; sequence id not in genome; transcript id unresolved for a coding effect.",
+  };
+}
+
+sub new {
+  my $class = shift;
+  my $self = {};
+  bless($self, $class);
+  $self->initialize({
+    requiredDbVersion => 4.0,
+    cvsRevision       => '$Revision$',
+    name              => ref($self),
+    argsDeclaration   => getArgsDeclaration(),
+    documentation     => getDocumentation(),
+  });
+  return $self;
+}
+
+sub run { die "not yet implemented\n"; }
+
+1;
+```
+
+- [ ] **Step 2: Build and verify the plugin loads**
+
+```bash
+$PROJECT_HOME/install/bin/build ApiCommonData -append
+perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
+```
+Expected: `... syntax OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/plugin/perl/InsertVariationFeatures.pm
+git commit -m "feat: InsertVariationFeatures plugin skeleton (args, docs)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Plugin — DB queries (transcript map + sequence validation)
+
+**File:** Modify `ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm`
+
+These use the plugin's `getQueryHandle()` (a live DBI handle) and are verified SQL from the spec.
+
+- [ ] **Step 1: Add `getTranscriptMap` and `getGenomicSequenceIds`** (before `1;`)
+
+```perl
+sub getTranscriptMap {
+  my ($self, $organismAbbrev) = @_;
+  my $dbh = $self->getQueryHandle();
+  my $sql = "
+    SELECT t.source_id, t.na_feature_id
+    FROM   dots.Transcript t, dots.NaSequence ns, apidb.Organism o
+    WHERE  t.na_sequence_id = ns.na_sequence_id
+      AND  ns.taxon_id      = o.taxon_id
+      AND  o.abbrev         = ?";
+  my $sth = $dbh->prepare($sql);
+  $sth->execute($organismAbbrev);
+  my %map;
+  while (my ($sid, $nfid) = $sth->fetchrow_array) { $map{$sid} = $nfid; }
+  $self->error("No transcripts found for organismAbbrev '$organismAbbrev' - is it loaded?")
+    unless %map;
+  $self->log("Loaded " . scalar(keys %map) . " transcript ids for $organismAbbrev");
+  return \%map;
+}
+
+sub getGenomicSequenceIds {
+  my ($self, $organismAbbrev) = @_;
+  my $dbh = $self->getQueryHandle();
+  my $sql = "
+    SELECT ens.source_id
+    FROM   dots.ExternalNaSequence ens, apidb.Organism o
+    WHERE  ens.taxon_id = o.taxon_id
+      AND  o.abbrev     = ?";
+  my $sth = $dbh->prepare($sql);
+  $sth->execute($organismAbbrev);
+  my %seqIds;
+  while (my ($sid) = $sth->fetchrow_array) { $seqIds{$sid} = 1; }
+  return \%seqIds;
+}
+
+# Reads distinct seq_id (column 2) from variationFeature.dat and dies if any is
+# not a genomic sequence for this organism. Nothing else protects
+# VariationFeature.sequence_source_id (it is a bare VARCHAR with no FK).
+sub validateSequenceIds {
+  my ($self, $inputDir, $validSeqIds) = @_;
+  open(my $fh, '<', "$inputDir/variationFeature.dat")
+    or $self->error("Cannot open $inputDir/variationFeature.dat: $!");
+  <$fh>; # header
+  my %seen;
+  while (my $line = <$fh>) {
+    chomp $line;
+    my @f = split /\t/, $line, -1;
+    $seen{$f[1]} = 1;
+  }
+  close $fh;
+  my @bad = grep { !$validSeqIds->{$_} } sort keys %seen;
+  $self->error("variationFeature.dat references sequence ids not in this organism's genome: "
+    . join(", ", @bad)) if @bad;
+  $self->log("Validated " . scalar(keys %seen) . " distinct sequence ids");
+}
+```
+
+- [ ] **Step 2: Build and syntax-check**
+
+```bash
+$PROJECT_HOME/install/bin/build ApiCommonData -append
+perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
+```
+Expected: `syntax OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/plugin/perl/InsertVariationFeatures.pm
+git commit -m "feat: InsertVariationFeatures organism-scoped transcript map + seq validation
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Plugin — psql orchestration (transform + single-transaction load)
+
+**File:** Modify `ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm`
+
+- [ ] **Step 1: Add connection parsing and the loader** (before `1;`)
+
+```perl
+# Parse host/port/dbname out of the gus.config dbiDsn. NOTE: the port matters —
+# the default config runs on 5433, and psql defaults to 5432, so an omitted port
+# silently hits the wrong database.
+sub getPsqlConnection {
+  my ($self) = @_;
+  my $cfg = GUS::Supported::GusConfig->new();
+  my $dsn = $cfg->getDbiDsn();     # dbi:Pg:dbname=...;host=...;port=...
+  my ($dbname) = $dsn =~ /dbname=([^;]+)/;
+  my ($host)   = $dsn =~ /host=([^;]+)/;
+  my ($port)   = $dsn =~ /port=([^;]+)/;
+  return {
+    login    => $cfg->getDatabaseLogin(),
+    password => $cfg->getDatabasePassword(),
+    dbname   => $dbname,
+    host     => $host || 'localhost',
+    port     => $port || 5432,
+  };
+}
+
+# Build a single-line \copy command. Psql.pm's getCommand() emits multi-line,
+# which fails in a psql -f script, so we assemble it here.
+sub copyCommand {
+  my ($self, $table, $columns, $file) = @_;
+  my $cols = join(", ", @$columns);
+  # QUOTE '`' matches Psql.pm and is verified against this data (no backticks,
+  # double quotes, or CRs occur in any field). The data is unquoted, so QUOTE
+  # only needs to be a byte that never appears.
+  return "\\copy $table ($cols) FROM '$file' "
+       . "WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\`', ENCODING 'UTF8')";
+}
+
+sub loadAll {
+  my ($self, $schema, $extDbRlsId, $vfFile, $tpFile, $veFile) = @_;
+  my $conn = $self->getPsqlConnection();
+  my $dir  = tempdir(CLEANUP => 1);
+  my $sqlFile = "$dir/load.sql";
+
+  open(my $sql, '>', $sqlFile) or $self->error("Cannot write $sqlFile: $!");
+  print $sql "BEGIN;\n";
+  print $sql "DELETE FROM $schema.VariationFeature WHERE external_database_release_id = $extDbRlsId;\n";
+  print $sql $self->copyCommand("$schema.VariationFeature",           variationFeatureColumns(),  $vfFile) . "\n";
+  print $sql $self->copyCommand("$schema.VariationTranscriptProduct", transcriptProductColumns(), $tpFile) . "\n";
+  print $sql $self->copyCommand("$schema.VariationEffect",            variationEffectColumns(),   $veFile) . "\n";
+  print $sql "COMMIT;\n";
+  close $sql;
+
+  my $connStr = "postgresql://$conn->{login}:$conn->{password}\@$conn->{host}:$conn->{port}/$conn->{dbname}";
+  my $logFile = "$dir/psql.log";
+  my $cmd = "psql -v ON_ERROR_STOP=1 --log-file='$logFile' -f '$sqlFile' '$connStr'";
+
+  $self->log("Running single-transaction load via psql");
+  my $rc = system($cmd);
+  if ($rc != 0) {
+    $self->printFile($logFile);
+    $self->error("psql load failed (rc=$rc); transaction rolled back, prior data intact");
+  }
+}
+
+sub printFile {
+  my ($self, $file) = @_;
+  return unless -e $file;
+  open(my $fh, '<', $file) or return;
+  while (<$fh>) { $self->log("psql: $_") }
+  close $fh;
+}
+```
+
+- [ ] **Step 2: Build and syntax-check**
+
+```bash
+$PROJECT_HOME/install/bin/build ApiCommonData -append
+perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
+```
+Expected: `syntax OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/plugin/perl/InsertVariationFeatures.pm
+git commit -m "feat: InsertVariationFeatures single-transaction psql loader
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Plugin — wire run() together
+
+**File:** Modify `ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm`
+
+- [ ] **Step 1: Replace the stub `run`**
+
+```perl
+sub run {
+  my ($self) = @_;
+
+  my $inputDir       = $self->getArg('inputDir');
+  my $organismAbbrev = $self->getArg('organismAbbrev');
+  my $schema         = $self->getArg('targetSchema');
+  my $extDbRlsId     = $self->getExtDbRlsId($self->getArg('extDbRlsSpec'))
+    or $self->error("Cannot resolve extDbRlsSpec: " . $self->getArg('extDbRlsSpec'));
+
+  my $map      = $self->getTranscriptMap($organismAbbrev);
+  my $validSeq = $self->getGenomicSequenceIds($organismAbbrev);
+  $self->validateSequenceIds($inputDir, $validSeq);
+
+  my $dir = tempdir(CLEANUP => 1);
+  my ($vf, $tp, $ve) = ("$dir/vf.tmp", "$dir/tp.tmp", "$dir/ve.tmp");
+
+  my $nvf = $self->transformFile($inputDir, 'variationFeature.dat', $vf,
+    sub { transformVariationFeature($_[0], $_[1], $extDbRlsId) });
+  my $ntp = $self->transformFile($inputDir, 'transcript_product.dat', $tp,
+    sub { transformTranscriptProduct($_[0], $_[1], $map) });
+  my $nve = $self->transformFile($inputDir, 'snpeff.dat', $ve,
+    sub { transformVariationEffect($_[0], $_[1], $map) });
+
+  $self->loadAll($schema, $extDbRlsId, $vf, $tp, $ve);
+
+  return "Loaded VariationFeature=$nvf VariationTranscriptProduct=$ntp VariationEffect=$nve";
+}
+
+sub transformFile {
+  my ($self, $inputDir, $name, $outFile, $transform) = @_;
+  open(my $in,  '<', "$inputDir/$name") or $self->error("Cannot open $inputDir/$name: $!");
+  open(my $out, '>', $outFile)          or $self->error("Cannot write $outFile: $!");
+  my $n = eval { $transform->($in, $out) };
+  $self->error("Transform of $name failed: $@") if $@;
+  close $in; close $out;
+  $self->log("Transformed $name: $n rows");
+  return $n;
+}
+```
+
+- [ ] **Step 2: Build and syntax-check**
+
+```bash
+$PROJECT_HOME/install/bin/build ApiCommonData -append
+perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
+```
+Expected: `syntax OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/plugin/perl/InsertVariationFeatures.pm
+git commit -m "feat: InsertVariationFeatures run() orchestration
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Plugin — undo via undoPreprocess
+
+**File:** Modify `ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm`
+
+The `Undo.pm` framework constructs the plugin with a bare `new()` — no `getArg`, no
+initialized handle. Recover `extDbRlsSpec` from `core.AlgorithmParam` and resolve it to
+an id with plain SQL, then delete (children cascade).
+
+- [ ] **Step 1: Add undo methods** (before `1;`)
+
+```perl
+sub undoTables { return (); }   # no row_alg_invocation_id on these tables
+
+sub undoPreprocess {
+  my ($self, $dbh, $rowAlgInvocationList) = @_;
+
+  my $specs = $self->getAlgorithmParam($dbh, $rowAlgInvocationList, 'extDbRlsSpec');
+  $self->error("undo: could not recover extDbRlsSpec from core.AlgorithmParam")
+    unless $specs && @$specs;
+
+  # targetSchema is optional; default to apidb if it was not recorded.
+  my $schemas = $self->getAlgorithmParam($dbh, $rowAlgInvocationList, 'targetSchema');
+  my $schema  = ($schemas && @$schemas && $schemas->[0]) ? $schemas->[0] : 'apidb';
+
+  foreach my $spec (@$specs) {
+    my ($name, $version) = split /\|/, $spec;
+    my $sql = "
+      SELECT r.external_database_release_id
+      FROM   sres.ExternalDatabaseRelease r, sres.ExternalDatabase d
+      WHERE  d.external_database_id = r.external_database_id
+        AND  d.name = ? AND r.version = ?";
+    my $sth = $dbh->prepare($sql);
+    $sth->execute($name, $version);
+    my ($id) = $sth->fetchrow_array;
+    $self->error("undo: no external_database_release_id for '$spec'") unless $id;
+
+    my $del = $dbh->prepare("DELETE FROM $schema.VariationFeature WHERE external_database_release_id = ?");
+    my $n = $del->execute($id);
+    $self->log("undo: deleted $n VariationFeature rows (children cascade) for $spec");
+  }
+}
+
+# Recover a plugin argument's recorded value(s) from core.AlgorithmParam, keyed by
+# plugin name and invocation id. Pattern from InsertEdaStudyFromArtifacts.
+sub getAlgorithmParam {
+  my ($self, $dbh, $rowAlgInvocationList, $paramKey) = @_;
+  my $pluginName = ref($self);
+  my @values;
+  foreach my $rowAlgInvId (@$rowAlgInvocationList) {
+    my $sql = "SELECT p.STRING_VALUE
+      FROM core.ALGORITHMPARAMKEY k
+      LEFT JOIN core.ALGORITHMIMPLEMENTATION a ON k.ALGORITHM_IMPLEMENTATION_ID = a.ALGORITHM_IMPLEMENTATION_ID
+      LEFT JOIN core.ALGORITHMPARAM p ON k.ALGORITHM_PARAM_KEY_ID = p.ALGORITHM_PARAM_KEY_ID
+      WHERE a.EXECUTABLE = ? AND p.ROW_ALG_INVOCATION_ID = ? AND k.ALGORITHM_PARAM_KEY = ?";
+    my $sth = $dbh->prepare($sql);
+    $sth->execute($pluginName, $rowAlgInvId, $paramKey);
+    while (my ($v) = $sth->fetchrow_array) { push @values, $v if defined $v; }
+  }
+  return \@values;
+}
+```
+
+- [ ] **Step 2: Build and syntax-check**
+
+```bash
+$PROJECT_HOME/install/bin/build ApiCommonData -append
+perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
+```
+Expected: `syntax OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/plugin/perl/InsertVariationFeatures.pm
+git commit -m "feat: InsertVariationFeatures undo via undoPreprocess
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Integration test against the jbrestel stub schema
+
+**File:** Create `ApiCommonData/Load/t/insertVariationFeatures_integration.t`
+
+This does not run the plugin through GUS (which needs a full workflow context). It exercises
+the transform + single-transaction load path — the parts unique to this loader — against the
+real `jbrestel` stub schema, using the transform functions directly.
+
+- [ ] **Step 1: Ensure the stub schema exists**
+
+```bash
+psql -h localhost -p 5432 -d unidb_shu_a -tAc \
+  "SELECT count(*) FROM jbrestel.stubtranscript;"
+```
+Expected: `78`. If the schema is gone, recreate it with the scratchpad SQL
+(`create_jbrestel_stub.sql`) and re-seed `stub_transcript.dat`.
+
+- [ ] **Step 2: Write the integration test**
+
+```perl
+use strict;
+use warnings;
+use lib "$ENV{PROJECT_HOME}/ApiCommonData/Load/lib/perl";
+use Test::More;
+use File::Temp qw/tempdir/;
+use ApiCommonData::Load::VariationLoader qw/
+  variationFeatureColumns transcriptProductColumns variationEffectColumns
+  transformVariationFeature transformTranscriptProduct transformVariationEffect
+/;
+
+my $INPUT = '/home/jbrestel/dnaseq_test/merge/output';
+my $DB    = 'unidb_shu_a';
+plan skip_all => "sample data $INPUT not present" unless -d $INPUT;
+
+# Build the transcript map from jbrestel.StubTranscript via psql.
+my %map;
+open(my $m, "-|", "psql -h localhost -p 5432 -d $DB -tAF'\t' -c "
+  . "'SELECT source_id, na_feature_id FROM jbrestel.stubtranscript'") or die $!;
+while (<$m>) { chomp; my ($s,$n) = split /\t/; $map{$s} = $n if $s; }
+close $m;
+is(scalar keys %map, 78, 'stub transcript map has 78 entries');
+
+my $dir = tempdir(CLEANUP => 1);
+my %n;
+for ([qw/variationFeature.dat vf/], [qw/transcript_product.dat tp/], [qw/snpeff.dat ve/]) {
+  my ($file, $tag) = @$_;
+  open(my $in, '<', "$INPUT/$file") or die $!;
+  open(my $out, '>', "$dir/$tag.tmp") or die $!;
+  $n{$tag} =
+      $tag eq 'vf' ? transformVariationFeature($in, $out, 1)
+    : $tag eq 'tp' ? transformTranscriptProduct($in, $out, \%map)
+    :                transformVariationEffect($in, $out, \%map);
+  close $in; close $out;
+}
+is($n{vf}, 1504, 'vf rows'); is($n{tp}, 781, 'tp rows'); is($n{ve}, 1978, 've rows');
+
+# Assemble and run the single-transaction load into jbrestel.
+my $vfCols = join(", ", @{variationFeatureColumns()});
+my $tpCols = join(", ", @{transcriptProductColumns()});
+my $veCols = join(", ", @{variationEffectColumns()});
+my $sqlFile = "$dir/load.sql";
+open(my $s, '>', $sqlFile) or die $!;
+print $s "BEGIN;\n";
+print $s "DELETE FROM jbrestel.VariationFeature WHERE external_database_release_id = 1;\n";
+print $s "\\copy jbrestel.VariationFeature ($vfCols) FROM '$dir/vf.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\`', ENCODING 'UTF8')\n";
+print $s "\\copy jbrestel.VariationTranscriptProduct ($tpCols) FROM '$dir/tp.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\`', ENCODING 'UTF8')\n";
+print $s "\\copy jbrestel.VariationEffect ($veCols) FROM '$dir/ve.tmp' WITH (FORMAT CSV, DELIMITER E'\\t', QUOTE '\`', ENCODING 'UTF8')\n";
+print $s "COMMIT;\n";
+close $s;
+
+my $rc = system("psql -h localhost -p 5432 -d $DB -v ON_ERROR_STOP=1 -f '$sqlFile' >/dev/null 2>&1");
+is($rc, 0, 'single-transaction load succeeded');
+
+sub count1 {
+  my ($tbl) = @_;
+  my $c = `psql -h localhost -p 5432 -d $DB -tAc "SELECT count(*) FROM jbrestel.$tbl"`;
+  chomp $c; return $c;
+}
+is(count1('VariationFeature'), 1504, 'VariationFeature loaded');
+is(count1('VariationTranscriptProduct'), 781, 'VariationTranscriptProduct loaded');
+is(count1('VariationEffect'), 1978, 'VariationEffect loaded');
+
+# Intergenic rows -> NULL na_feature_id: 1978 - 1181 = 797 non-null.
+my $nn = `psql -h localhost -p 5432 -d $DB -tAc "SELECT count(na_feature_id) FROM jbrestel.VariationEffect"`;
+chomp $nn;
+is($nn, 797, 'VariationEffect na_feature_id non-null count (empty -> NULL)');
+
+# Cascade delete clears all three (the undo path).
+system("psql -h localhost -p 5432 -d $DB -c 'DELETE FROM jbrestel.VariationFeature WHERE external_database_release_id = 1' >/dev/null 2>&1");
+is(count1('VariationTranscriptProduct'), 0, 'children cascade-deleted');
+
+done_testing;
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `cd $PROJECT_HOME && prove -v ApiCommonData/Load/t/insertVariationFeatures_integration.t`
+Expected: PASS — all counts as asserted.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd $PROJECT_HOME/ApiCommonData
+git add Load/t/insertVariationFeatures_integration.t
+git commit -m "test: integration load into jbrestel stub schema
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: End-to-end smoke via the real plugin (manual, optional)
+
+Requires a `gus.config` pointing at a database where the target tables and a real organism
+both exist. Not runnable against `unidb_shu_a` as-is (no *L. major*). Document the command
+for whoever has such an instance:
+
+```bash
+ga ApiCommonData::Load::Plugin::InsertVariationFeatures \
+  --inputDir /path/to/merge/output \
+  --extDbRlsSpec 'someVariation_RSRC|2026-07-10' \
+  --organismAbbrev lmajFriedlin \
+  --commit
+```
+
+Undo:
+
+```bash
+ga GUS::Community::Plugin::Undo \
+  --plugin ApiCommonData::Load::Plugin::InsertVariationFeatures \
+  --algInvocationId <id> --commit
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** schema changes (T1), transforms incl. all three files and null/fatal
+  rules (T3–5), organism-scoped map + sequence validation (T7), single-transaction load with
+  correct port handling (T8), run() wiring (T9), undoPreprocess (T10), integration incl.
+  atomicity-relevant counts and cascade (T11). All spec sections map to a task.
+- **QUOTE character:** the plan uses backtick `` '`' `` — matching Psql.pm and verified
+  against the sample loads (no backticks, double quotes, or CRs occur in any field). The
+  data is unquoted, so QUOTE only needs a byte that never appears.
+- **Not covered by automated tests:** the full `ga` plugin invocation (needs workflow
+  context + a real organism), hence the manual T12. The DB-query methods (T7) and psql
+  orchestration (T8) are exercised by T11 via the same SQL, but not through the plugin's
+  own `getQueryHandle`. Acceptable given the environment; flagged honestly.

--- a/docs/superpowers/plans/2026-07-10-variation-dat-loader.md
+++ b/docs/superpowers/plans/2026-07-10-variation-dat-loader.md
@@ -294,7 +294,7 @@ use ApiCommonData::Load::VariationLoader qw/transformVariationFeature/;
   # 233 SNV row with empty indel_* fields
   my @vals = (233, 'LmjF.01', 'lmajFriedlin', 0, 'SNV',
     5,4,0,'1.0000',9,'0.7778',0, 'C','G','0.2222',1,'','','', 'LmjF.01:g.233C>G','',
-    '','','',  '','','',  '','','');
+    '','','',  '','','',  '','','', '');   # 31 values, matching the 31-col header
   my $row = join("\t", @vals);
 
   my ($inFh, $inFile)   = tempfile(UNLINK => 1);

--- a/docs/superpowers/plans/2026-07-10-variation-dat-loader.md
+++ b/docs/superpowers/plans/2026-07-10-variation-dat-loader.md
@@ -35,17 +35,39 @@
 export PROJECT_HOME=/home/jbrestel/workspaces/dataLoad/project_home
 export GUS_HOME=/home/jbrestel/workspaces/dataLoad/gus_home
 export PATH=$GUS_HOME/bin:$PATH
-export PERL5LIB=$GUS_HOME/lib/perl
+export PERL5LIB=$GUS_HOME/lib/perl:/home/jbrestel/perl5/lib/perl5
 ```
 
-`GUS_HOME` holds **copies** of source, not symlinks. After editing any `.pm` under
-`$PROJECT_HOME/ApiCommonData`, reinstall before running the plugin:
+**Module resolution (important — do not skip):** Source `.pm` files live *flat* under
+`Load/lib/perl/` (e.g. `Load/lib/perl/VariationLoader.pm`) but declare the full package
+`ApiCommonData::Load::VariationLoader`. Perl can only resolve that from a directory that
+has an `ApiCommonData/Load/` subtree — i.e. the **built** copy at
+`$GUS_HOME/lib/perl/ApiCommonData/Load/`. Therefore:
 
-```bash
-$PROJECT_HOME/install/bin/build ApiCommonData -append
-```
+- Every `.t` file uses `use lib "$ENV{GUS_HOME}/lib/perl";` (matching all existing repo
+  tests), **not** a `$PROJECT_HOME/...` path.
+- After editing any `.pm`, sync it into the built tree before running tests or the plugin.
+  Dev-loop sync (fast; what to use during this work):
 
-Unit tests (Task 2–5) run directly from `$PROJECT_HOME` without a build and without a DB.
+  ```bash
+  cp $PROJECT_HOME/ApiCommonData/Load/lib/perl/VariationLoader.pm \
+     $GUS_HOME/lib/perl/ApiCommonData/Load/
+  # plugin file, when it exists:
+  cp $PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm \
+     $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/
+  ```
+
+  The full deploy build is `build ApiCommonData install ...` (heavyweight: touches config
+  and DB schema). Do **not** run it for this dev loop; the `cp` sync is sufficient and is
+  standard GUS dev practice. The committed source is the source of truth; the `cp` is a
+  local install step, never committed.
+
+- `Test::Exception` is a repo test dependency (used by `ontology_mapping.t`). If missing,
+  install once: `cpanm --local-lib=/home/jbrestel/perl5 Test::Exception`. The `PERL5LIB`
+  above already includes `/home/jbrestel/perl5/lib/perl5`.
+
+Unit tests (Tasks 2–5) need the `cp` sync but no DB. The integration test (Task 11) needs
+both the sync and the live `unidb_shu_a` database.
 
 ## File structure
 
@@ -131,7 +153,7 @@ Create `ApiCommonData/Load/t/variationLoader.t`:
 ```perl
 use strict;
 use warnings;
-use lib "$ENV{PROJECT_HOME}/ApiCommonData/Load/lib/perl";
+use lib "$ENV{GUS_HOME}/lib/perl";
 use Test::More;
 use Test::Exception;
 use ApiCommonData::Load::VariationLoader qw/
@@ -640,7 +662,7 @@ sub run { die "not yet implemented\n"; }
 - [ ] **Step 2: Build and verify the plugin loads**
 
 ```bash
-$PROJECT_HOME/install/bin/build ApiCommonData -append
+cp $PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/
 perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
 ```
 Expected: `... syntax OK`.
@@ -725,7 +747,7 @@ sub validateSequenceIds {
 - [ ] **Step 2: Build and syntax-check**
 
 ```bash
-$PROJECT_HOME/install/bin/build ApiCommonData -append
+cp $PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/
 perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
 ```
 Expected: `syntax OK`.
@@ -819,7 +841,7 @@ sub printFile {
 - [ ] **Step 2: Build and syntax-check**
 
 ```bash
-$PROJECT_HOME/install/bin/build ApiCommonData -append
+cp $PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/
 perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
 ```
 Expected: `syntax OK`.
@@ -886,7 +908,7 @@ sub transformFile {
 - [ ] **Step 2: Build and syntax-check**
 
 ```bash
-$PROJECT_HOME/install/bin/build ApiCommonData -append
+cp $PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/
 perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
 ```
 Expected: `syntax OK`.
@@ -968,7 +990,7 @@ sub getAlgorithmParam {
 - [ ] **Step 2: Build and syntax-check**
 
 ```bash
-$PROJECT_HOME/install/bin/build ApiCommonData -append
+cp $PROJECT_HOME/ApiCommonData/Load/plugin/perl/InsertVariationFeatures.pm $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/
 perl -c $GUS_HOME/lib/perl/ApiCommonData/Load/Plugin/InsertVariationFeatures.pm
 ```
 Expected: `syntax OK`.
@@ -1007,7 +1029,7 @@ Expected: `78`. If the schema is gone, recreate it with the scratchpad SQL
 ```perl
 use strict;
 use warnings;
-use lib "$ENV{PROJECT_HOME}/ApiCommonData/Load/lib/perl";
+use lib "$ENV{GUS_HOME}/lib/perl";
 use Test::More;
 use File::Temp qw/tempdir/;
 use ApiCommonData::Load::VariationLoader qw/

--- a/docs/superpowers/specs/2026-07-10-variation-dat-loader-design.md
+++ b/docs/superpowers/specs/2026-07-10-variation-dat-loader-design.md
@@ -77,23 +77,57 @@ same is true of `source_id`. This is an accepted constraint of the design, not a
 oversight, but it must be stated: **the tables model "the variation calls for this
 genome," not "the variation calls from this experiment."**
 
-### Consequence: `undoTables` does not work
+### Consequence: undo goes through `undoPreprocess`, not `undoTables`
 
 The schema commit deliberately omits housekeeping columns and a `core.TableInfo` entry
-(legacy SNP-table precedent). GUS's undo machinery deletes by `row_alg_invocation_id`
-and resolves tables through `core.TableInfo`; these tables have neither. Every plugin
-precedent (`InsertAlphaFold`, `InsertSyntenySpans`) gets undo for free. **We do not.**
+(legacy SNP-table precedent). `GUS::Community::Plugin::Undo` (`Undo.pm`) implements
+`undoTables` by issuing `DELETE FROM <table> WHERE row_alg_invocation_id IN (...)`.
+These tables have no such column, so **`undoTables` must return `()`**.
 
-Undo is therefore explicit, and the loader owns it:
+`Undo.pm` provides a second, undocumented hook. Its `run()` does, in order:
 
-```sql
-DELETE FROM apidb.VariationFeature WHERE external_database_release_id = <id>;
+1. `$plugin = $pluginName->new()` — a **fresh, uninitialized** plugin instance.
+2. `$plugin->undoPreprocess($dbh, $algInvocationIds)`, inside a transaction with
+   `AutoCommit=0`, committed if `--commit`. A missing method is caught and skipped.
+3. Deletes each `undoTables()` entry by `row_alg_invocation_id`.
+4. Deletes `Core.AlgorithmParam`, then `Core.AlgorithmInvocation`.
+
+Because step 2 precedes step 4, `undoPreprocess` can still read the plugin's original
+arguments out of `core.AlgorithmParam`. Because the instance in step 1 is fresh,
+`getArg()` and the initialized GUS handle are **not** available — arguments must be
+recovered by querying the passed `$dbh`. `InsertEdaStudyFromArtifacts` is the
+reference implementation, via its `getAlgorithmParam($dbh, $rowAlgInvocationList, $key)`
+helper, which joins `core.AlgorithmParamKey`, `core.AlgorithmImplementation`, and
+`core.AlgorithmParam` on the plugin name and invocation id.
+
+So this loader implements:
+
+```perl
+sub undoTables { return (); }
+
+sub undoPreprocess {
+  my ($self, $dbh, $rowAlgInvocationList) = @_;
+  my $spec = $self->getAlgorithmParam($dbh, $rowAlgInvocationList, 'extDbRlsSpec')->[0];
+  # resolve $spec -> external_database_release_id against $dbh, then:
+  #   DELETE FROM apidb.VariationFeature WHERE external_database_release_id = ?
+}
 ```
 
-`ON DELETE CASCADE` on both children clears them. This is what the schema's cascade
-was designed for. The absence of `core.TableInfo` also means no `GUS::Model::ApiDB::*`
-classes exist, so object-based inserts are unavailable: `COPY` is not merely the fast
-path, it is the only path.
+`ON DELETE CASCADE` on both children clears them. Resolve the spec with plain SQL
+against `sres.ExternalDatabaseRelease`/`sres.ExternalDatabase` rather than
+`$self->getExtDbRlsId`, which needs an initialized plugin.
+
+The arg must be named exactly `extDbRlsSpec`, since that string is the
+`core.AlgorithmParamKey` lookup key.
+
+Note this deletes **all** rows for that external database release, not merely those
+from the given algorithm invocation. Given no per-invocation tracking exists in these
+tables, that is the only available granularity, and it is consistent with the
+one-dataset-per-genome constraint above.
+
+The absence of `core.TableInfo` also means no `GUS::Model::ApiDB::*` classes exist, so
+object-based inserts are unavailable: `COPY` is not merely the fast path, it is the
+only path.
 
 ## Loader design
 
@@ -200,8 +234,24 @@ failure so the offending row can be inspected.
 
 Load order is parent then children, or the foreign key checks fail.
 
-The leading `DELETE` makes re-running the loader idempotent — which matters
-disproportionately, because it is the *only* undo these tables have.
+The leading `DELETE` makes re-running the loader idempotent, and mirrors exactly what
+`undoPreprocess` does.
+
+**Verified against `unidb_shu_a` (2026-07-10), loading the sample data into `jbrestel`:**
+
+- One transaction loads 1504 / 781 / 1978 rows. Empty fields become NULL:
+  `VariationEffect.na_feature_id` is non-null in exactly 797 rows (1978 − 1181
+  intergenic); `indel_frame_effect` in exactly 273 (207 + 42 + 24).
+- Re-running is idempotent: `DELETE 1504`, reload, identical counts.
+- **Atomicity holds.** Appending one FK-violating row to the third `\COPY` aborts the
+  transaction and the pre-existing 1504 / 781 / 1978 survive — the leading `DELETE`
+  does *not* commit. Under three separate `psql --command` invocations the same
+  failure would have committed the `DELETE` and both parent COPYs, leaving a reloaded
+  parent and an empty `VariationEffect`. This is the concrete reason for the single
+  script.
+- Cascade delete by `external_database_release_id` clears all three tables (0 / 0 / 0).
+- `Psql.pm`'s exact `\COPY` configuration (`FORMAT CSV, DELIMITER E'\t', QUOTE '` + "`" + `'`)
+  round-trips the data unchanged.
 
 ### Step 6 — report
 
@@ -222,13 +272,14 @@ construction, empty-to-NULL passthrough, intergenic NULL `na_feature_id`, and fa
 handling of an unresolvable transcript id. No database required, which is the point of
 factoring the transform out of the plugin.
 
-**Integration (`jbrestel` schema).** Create `jbrestel` (it does not exist yet), holding
+**Integration (`jbrestel` schema).** *Created 2026-07-10.* The `jbrestel` schema holds
 copies of the three tables *without* the `dots`/`sres` foreign keys but *with* the
-parent→child `ON DELETE CASCADE`, plus a stub transcript relation carrying the 78
-`LmjF` source ids mapped to synthetic `na_feature_id`s. Run the loader with
-`--targetSchema jbrestel`. This exercises the generated SQL script end to end: column
-order, null handling, load ordering, cascade delete, transaction atomicity, and
-idempotent re-run.
+parent→child `ON DELETE CASCADE`, plus `jbrestel.StubTranscript` carrying the 78 `LmjF`
+source ids mapped to synthetic `na_feature_id`s (9000001+, chosen not to collide with
+real values). Run the loader with `--targetSchema jbrestel`. This exercises the
+generated SQL script end to end: column order, null handling, load ordering, cascade
+delete, transaction atomicity, and idempotent re-run — all four already confirmed by
+hand with a throwaway prototype of the transform.
 
 **Lookup query (real data).** The organism-scoped transcript query and the sequence
 validation query are tested directly against `afumAf293`, which is really loaded.
@@ -258,7 +309,8 @@ separately against real data.
 |---|---|
 | Perl GUS plugin, not standalone script | Consistency; `getExtDbRlsId`, `--commit` semantics |
 | Temp files + `\COPY`, not `DBD::Pg` `pg_putcopydata` | Repo precedent; `Psql.pm` reuse |
-| One psql script, not three `system()` calls | Atomicity across a parent and two FK children |
+| One psql script, not three `system()` calls | Atomicity across a parent and two FK children (verified) |
+| Empty `undoTables()` + `undoPreprocess()` | No `row_alg_invocation_id`; recover `extDbRlsSpec` from `core.AlgorithmParam` |
 | `source_id` = `Variant_<seq>_<loc>` | Stable across re-merges; `variant_type` is derived |
 | `source_id` on parent only | Avoids denormalizing an identifier into three tables |
 | Drop `downstream_of_frameshift_strain_ids` | Dangling reference to unloaded `sample.dat` |

--- a/docs/superpowers/specs/2026-07-10-variation-dat-loader-design.md
+++ b/docs/superpowers/specs/2026-07-10-variation-dat-loader-design.md
@@ -68,14 +68,29 @@ Not loaded: `allele.dat`, `sample.dat`, `merged.ann.vcf.gz`, the `hsss_readFreq*
 `(sequence_source_id, location)` and the child tables keep their existing composite
 foreign key. `source_id` is **not** denormalized onto the children.
 
-### Consequence: one variation dataset per genome
+### Assumption: one variation dataset per genome
 
 `VariationFeature`'s primary key is `(sequence_source_id, location)` and carries no
 `external_database_release_id`. Two variation datasets for the same organism — say,
 different strain sets — cannot coexist; the second collides on the primary key. The
-same is true of `source_id`. This is an accepted constraint of the design, not an
-oversight, but it must be stated: **the tables model "the variation calls for this
-genome," not "the variation calls from this experiment."**
+same is true of `source_id`. **Accepted:** the tables model "the variation calls for
+this genome," not "the variation calls from this experiment." `mergeExperiments`
+produces one merged call set per organism, so this matches the pipeline.
+
+### Uniqueness of `source_id`
+
+`Variant_<seq>_<loc>` is unique iff genomic sequence source ids are unique across
+organisms. Verified in `unidb_shu_a`: `dots.ExternalNaSequence` (a view over
+`dots.NaSequence`, restricted to genomic sequences) has zero duplicate `source_id`s
+across all 8 loaded organisms.
+
+Note this is a *data property*, not an enforced constraint — `dots.NaSequence` in a
+UniDB build carries zero indexes and zero constraints, not even a primary key. The
+guarantee we actually rely on is our own `UNIQUE (source_id)` on `VariationFeature`,
+which turns any hypothetical cross-organism collision into a loud load failure rather
+than a silent merge of two organisms' variants. (The one duplicate in the base table
+is 79 `SplicedNASequence` rows sharing an empty `source_id` — transcript sequences
+with no id, outside the genomic view.)
 
 ### Consequence: undo goes through `undoPreprocess`, not `undoTables`
 
@@ -299,9 +314,8 @@ separately against real data.
   the sample (zero `&` in 1,978 rows). If a future SnpEff config stops splitting,
   `VariationEffect.effect VARCHAR(60)` will start truncating. Worth a full-size run
   before production.
-- **`--targetSchema`** is a test affordance in production code. It is small and
-  documented, but it is a seam that will be misused eventually if left undefended;
-  default it to `apidb` and never document it as a user-facing knob.
+- **`--targetSchema`** is a test affordance in production code (accepted 2026-07-10).
+  Default it to `apidb` and do not document it as a user-facing knob.
 
 ## Decisions log
 

--- a/docs/superpowers/specs/2026-07-10-variation-dat-loader-design.md
+++ b/docs/superpowers/specs/2026-07-10-variation-dat-loader-design.md
@@ -1,0 +1,266 @@
+# Loading mergeExperiments variation `.dat` files into ApiDB relational tables
+
+**Date:** 2026-07-10
+**Status:** design approved, not yet implemented
+**Repos touched:** `ApiCommonData` (loader), `ApidbSchema` branch `dnaseq-tables` (DDL)
+
+## Problem
+
+The `dnaseq-nextflow` `mergeExperiments` workflow emits tab-delimited `.dat` files
+describing sequence variation across strains. Nothing loads them. There are no
+loading notes anywhere in `dnaseq-nextflow` — only the README's "Outputs are
+intended for loading into a GUS/VEuPathDB database." The column contracts live in
+`dnaseq-nextflow/docs/superpowers/specs/2026-07-06-variationfeature-per-class-schema-design.md`
+and `2026-05-13-hsss-and-product-dat-gene-level.md`.
+
+Three new tables exist in `ApidbSchema` branch `dnaseq-tables`
+(`Main/lib/sql/apidbschema/Postgres/createVariationTables.sql`). We need a Perl
+loader consistent with this repo's conventions.
+
+## Input files
+
+From `mergeExperiments` output dir. Sample run: `/home/jbrestel/dnaseq_test/merge/output`
+(*L. major* Friedlin, 5 strains).
+
+| File | Rows (sample) | Target table |
+|---|---|---|
+| `variationFeature.dat` | 1,504 | `ApiDB.VariationFeature` |
+| `transcript_product.dat` | 781 | `ApiDB.VariationTranscriptProduct` |
+| `snpeff.dat` | 1,978 | `ApiDB.VariationEffect` |
+
+Not loaded: `allele.dat`, `sample.dat`, `merged.ann.vcf.gz`, the `hsss_readFreq*/` trees.
+
+**Conventions confirmed against the sample data:**
+
+- Tab-delimited, one header line. Only `transcript_product.dat` prefixes its header with `#`.
+- **Empty string means absent.** `FORMAT CSV` maps an unquoted empty field to NULL,
+  which is why `ApiCommonData::Load::Psql` deliberately omits its `NULL` clause.
+- No backticks, double quotes, or carriage returns in any field, so `Psql.pm`'s
+  backtick `QUOTE` character is safe.
+- `snpeff.dat` compound effects are already split on `&` into separate rows, so
+  `VariationEffect.effect VARCHAR(60)` is sufficient (longest observed: 30).
+- Verified: zero duplicate `(seq_id, location)` pairs; zero FK orphans between the
+  child files and `variationFeature.dat`; all values fit their declared column widths.
+
+## Schema changes (`ApidbSchema`, branch `dnaseq-tables`)
+
+1. **Add `ApiDB.VariationFeature.source_id VARCHAR(100) NOT NULL UNIQUE.`**
+   Format: `Variant_<sequence_source_id>_<location>` — e.g. `Variant_LmjF.01_233`.
+
+   The prefix is a **constant**, not `variant_type`. `variant_type` is derived from
+   the strain set: adding a strain can flip a locus `SNV` → `MIXED` (41 of 1,504 loci
+   in the sample are already `MIXED`). Embedding it would change the identifier of an
+   unchanged physical locus on every re-merge, silently breaking bookmarks, saved
+   strategies, and external links. The constant prefix namespaces the id against gene
+   and transcript source ids without that churn.
+
+   **The id is opaque. Do not parse it.** Sequence source ids may contain underscores
+   (`Variant_Chr1_A_fumigatus_Af293_233`), so it cannot be reliably split back into
+   `(sequence_source_id, location)` — and there is no need to, since both columns sit
+   alongside it. Sizing: `Variant_` (8) + 60 + `_` + 12 = 81; `VARCHAR(100)` for headroom.
+
+2. **Drop `ApiDB.VariationTranscriptProduct.downstream_of_frameshift_strain_ids`.**
+   Populated in 1 of 781 sample rows, with a value (`{1,3,4}`) referencing strain ids
+   from `sample.dat`, which we do not load. It would be a dangling pointer into a table
+   that does not exist. The `.dat` file retains the column for QA; the loader skips it.
+
+`source_id` gets a `UNIQUE` constraint (auto-indexed). The primary key stays
+`(sequence_source_id, location)` and the child tables keep their existing composite
+foreign key. `source_id` is **not** denormalized onto the children.
+
+### Consequence: one variation dataset per genome
+
+`VariationFeature`'s primary key is `(sequence_source_id, location)` and carries no
+`external_database_release_id`. Two variation datasets for the same organism — say,
+different strain sets — cannot coexist; the second collides on the primary key. The
+same is true of `source_id`. This is an accepted constraint of the design, not an
+oversight, but it must be stated: **the tables model "the variation calls for this
+genome," not "the variation calls from this experiment."**
+
+### Consequence: `undoTables` does not work
+
+The schema commit deliberately omits housekeeping columns and a `core.TableInfo` entry
+(legacy SNP-table precedent). GUS's undo machinery deletes by `row_alg_invocation_id`
+and resolves tables through `core.TableInfo`; these tables have neither. Every plugin
+precedent (`InsertAlphaFold`, `InsertSyntenySpans`) gets undo for free. **We do not.**
+
+Undo is therefore explicit, and the loader owns it:
+
+```sql
+DELETE FROM apidb.VariationFeature WHERE external_database_release_id = <id>;
+```
+
+`ON DELETE CASCADE` on both children clears them. This is what the schema's cascade
+was designed for. The absence of `core.TableInfo` also means no `GUS::Model::ApiDB::*`
+classes exist, so object-based inserts are unavailable: `COPY` is not merely the fast
+path, it is the only path.
+
+## Loader design
+
+`ApiCommonData::Load::Plugin::InsertVariationFeatures`
+
+**Arguments:** `--inputDir`, `--extDbRlsSpec`, `--organismAbbrev`,
+`--targetSchema` (default `apidb`; exists so integration tests can target `jbrestel`).
+
+### Step 1 — resolve the external database release
+
+Standard `$self->getExtDbRlsId($self->getArg('extDbRlsSpec'))`.
+
+### Step 2 — build the transcript map, scoped by organism
+
+```sql
+SELECT t.source_id, t.na_feature_id
+FROM   dots.Transcript t, dots.NaSequence ns, apidb.Organism o
+WHERE  t.na_sequence_id = ns.na_sequence_id
+  AND  ns.taxon_id      = o.taxon_id
+  AND  o.abbrev         = ?
+```
+
+Note the column is `apidb.organism.abbrev`, not `organism_abbrev`. Verified against
+`unidb_shu_a`: returns 10,130 transcripts for `afumAf293` out of 69,397 total.
+
+Transcript source ids happen to be globally unique in that database today, so the
+scoping is not strictly required for correctness. It is still right: it shrinks the
+hash roughly sevenfold, guards against future cross-organism collisions, and fails
+loudly if `--organismAbbrev` names an organism that isn't loaded. The sample data has
+78 distinct transcripts; production genomes have tens of thousands. A hash is fine.
+
+### Step 3 — validate the sequences belong to the organism
+
+`VariationFeature.sequence_source_id` is a bare `VARCHAR(60)` with no foreign key to
+`dots.NaSequence`. Nothing in the schema prevents loading *Leishmania* `.dat` files
+into an *Aspergillus* build; the rows would land happily and be wrong forever.
+
+Before loading, assert every distinct `seq_id` in `variationFeature.dat` appears in:
+
+```sql
+SELECT ens.source_id
+FROM   dots.ExternalNaSequence ens, apidb.Organism o
+WHERE  ens.taxon_id = o.taxon_id AND o.abbrev = ?
+```
+
+`dots.NaSequence` also holds transcript sequences, so the genomic-only
+`dots.ExternalNaSequence` is the correct relation (9 rows for `afumAf293`). Any
+unmatched `seq_id` is fatal. This converts a silent, permanent data-corruption bug
+into a load-time failure.
+
+### Step 4 — stream-transform each file to a temp file
+
+Each `.dat` is read line by line and written to a temp file whose columns match the
+`\COPY` field list. Memory stays constant apart from the transcript hash.
+
+Because `\COPY` takes an explicit field list, the physical column order of the tables
+is irrelevant; only agreement between the field list and the temp file matters.
+
+**`variationFeature.dat` → `VariationFeature`** (31 columns in, 33 out)
+- Prepend `source_id`, computed as `Variant_<seq_id>_<location>`.
+- Emit `seq_id` as `sequence_source_id`; reorder so it precedes `location`.
+- Append the constant `external_database_release_id`.
+
+**`transcript_product.dat` → `VariationTranscriptProduct`** (13 columns in, 12 out)
+- Strip the leading `#` from the header.
+- Drop column 12, `downstream_of_frameshift_strain_ids`.
+- Rename `count` → `strain_count`.
+- Resolve `transcript_id` → `na_feature_id`. **A miss is fatal** — the column is
+  `NOT NULL`. All 781 sample rows carry a transcript id.
+
+**`snpeff.dat` → `VariationEffect`** (8 columns in, 8 out)
+- Reorder to `sequence_source_id, location, allele, na_feature_id, impact, effect, hgvs_c, source`.
+- Resolve `transcript_id` → `na_feature_id`; an **empty** `transcript_id` yields NULL.
+
+  This is the common case, not an edge case: 1,181 of 1,978 sample rows are intergenic
+  and have no transcript. The code must never conflate "empty, therefore intergenic"
+  (normal) with "looked up and not found" (data corruption). The latter is fatal.
+
+### Step 5 — one psql invocation, one transaction
+
+Generate a single SQL script and run `psql -v ON_ERROR_STOP=1 -f <script>` **once**:
+
+```sql
+BEGIN;
+DELETE FROM <schema>.VariationFeature WHERE external_database_release_id = <id>;
+\COPY <schema>.VariationFeature (<fields>) FROM '<tmp1>' WITH (FORMAT CSV, ...)
+\COPY <schema>.VariationTranscriptProduct (<fields>) FROM '<tmp2>' WITH (FORMAT CSV, ...)
+\COPY <schema>.VariationEffect (<fields>) FROM '<tmp3>' WITH (FORMAT CSV, ...)
+COMMIT;
+```
+
+Reuse `ApiCommonData::Load::Psql`'s `getCommand()` to build each `\COPY` clause, but
+**not** its `getCommandLine()`. `getCommandLine()` wraps a single `\COPY` in its own
+`psql --command` invocation, which is what `InstallEdaStudyFromArtifacts` does per
+table. For a parent and two FK children that means three independent transactions: a
+failure loading `VariationEffect` leaves committed `VariationFeature` rows behind, and
+the only cleanup path is the cascade delete off a parent that may no longer be there.
+One script, one transaction.
+
+`InsertAlphaFold` streams into a named FIFO instead of a temp file, avoiding disk
+entirely. That works because it loads one table. Temp files are the right call here:
+they permit a single transaction across three ordered `\COPY`s, and they survive a
+failure so the offending row can be inspected.
+
+Load order is parent then children, or the foreign key checks fail.
+
+The leading `DELETE` makes re-running the loader idempotent — which matters
+disproportionately, because it is the *only* undo these tables have.
+
+### Step 6 — report
+
+Log rows read per file and rows loaded per table; verify they agree.
+
+## Testing
+
+`unidb_shu_a` contains *A. fumigatus*, *P. falciparum*, *T. gondii*, and others — but
+**no *L. major***. Zero `LmjF%` transcripts. The sample `.dat` files therefore cannot
+have their `na_feature_id` lookups satisfied against real `dots.Transcript` rows.
+
+Testing splits accordingly:
+
+**Unit (no database).** The per-file transforms are pure functions of
+`(input handle, transcript map, extDbRlsId)` → output lines. Test column reordering,
+the `#` header strip, the dropped column, `count` → `strain_count`, `source_id`
+construction, empty-to-NULL passthrough, intergenic NULL `na_feature_id`, and fatal
+handling of an unresolvable transcript id. No database required, which is the point of
+factoring the transform out of the plugin.
+
+**Integration (`jbrestel` schema).** Create `jbrestel` (it does not exist yet), holding
+copies of the three tables *without* the `dots`/`sres` foreign keys but *with* the
+parent→child `ON DELETE CASCADE`, plus a stub transcript relation carrying the 78
+`LmjF` source ids mapped to synthetic `na_feature_id`s. Run the loader with
+`--targetSchema jbrestel`. This exercises the generated SQL script end to end: column
+order, null handling, load ordering, cascade delete, transaction atomicity, and
+idempotent re-run.
+
+**Lookup query (real data).** The organism-scoped transcript query and the sequence
+validation query are tested directly against `afumAf293`, which is really loaded.
+Both are single SQL statements and have been verified by hand.
+
+Dropping the `dots`/`sres` foreign keys in the `jbrestel` copies costs little
+confidence: those constraints are Postgres's job, not the loader's, and the loader
+never constructs the values they guard except through the lookup, which is tested
+separately against real data.
+
+## Risks and open items
+
+- **`unidb_shu_a` crashed once** during ordinary read-only catalog queries
+  (`server terminated abnormally`, then connection-refused until manually restarted).
+  Cause unknown. Worth watching; unrelated to this design as far as anyone can tell.
+- **`snpeff.dat` `&`-splitting** is asserted by the pipeline author and consistent with
+  the sample (zero `&` in 1,978 rows). If a future SnpEff config stops splitting,
+  `VariationEffect.effect VARCHAR(60)` will start truncating. Worth a full-size run
+  before production.
+- **`--targetSchema`** is a test affordance in production code. It is small and
+  documented, but it is a seam that will be misused eventually if left undefended;
+  default it to `apidb` and never document it as a user-facing knob.
+
+## Decisions log
+
+| Decision | Rationale |
+|---|---|
+| Perl GUS plugin, not standalone script | Consistency; `getExtDbRlsId`, `--commit` semantics |
+| Temp files + `\COPY`, not `DBD::Pg` `pg_putcopydata` | Repo precedent; `Psql.pm` reuse |
+| One psql script, not three `system()` calls | Atomicity across a parent and two FK children |
+| `source_id` = `Variant_<seq>_<loc>` | Stable across re-merges; `variant_type` is derived |
+| `source_id` on parent only | Avoids denormalizing an identifier into three tables |
+| Drop `downstream_of_frameshift_strain_ids` | Dangling reference to unloaded `sample.dat` |
+| Scope transcript lookup by `--organismAbbrev` | Smaller hash, future collision safety, fail-fast |
+| Validate `seq_id`s against `ExternalNaSequence` | No FK protects `sequence_source_id` |


### PR DESCRIPTION
## Summary

Adds a GUS plugin that loads the `mergeExperiments` (dnaseq-nextflow) variation outputs — `variationFeature.dat`, `transcript_product.dat`, `snpeff.dat` — into `ApiDB.VariationFeature`, `VariationTranscriptProduct`, and `VariationEffect`.

- **`ApiCommonData::Load::VariationLoader`** — a pure module (no GUS, no DBI) defining the canonical column orders and the three file transforms. Unit-testable without a database.
- **`ApiCommonData::Load::Plugin::InsertVariationFeatures`** — resolves the external database release, builds an organism-scoped `transcript source_id → na_feature_id` map, validates that every sequence id belongs to the organism's genome, transforms each file to a temp file, and loads all three in a **single psql transaction** (`BEGIN; DELETE; \copy ×3; COMMIT;` with `ON_ERROR_STOP=1`).

### Key design points
- **One transaction** across a parent table and two FK-children (`ON DELETE CASCADE`). A failure in any `\copy` rolls back the whole load, so a failed reload leaves the prior data intact rather than a half-populated set. Verified.
- **`source_id` = `Variant_<sequence_source_id>_<location>`** — a stable, opaque identifier. A constant prefix, deliberately *not* `variant_type` (which is strain-set-derived and would churn the id across re-merges).
- **Undo via `undoPreprocess`**, not `undoTables` — these tables carry no `row_alg_invocation_id`, so undo recovers `extDbRlsSpec` from `core.AlgorithmParam` and deletes by `external_database_release_id` (children cascade).
- Intergenic `snpeff` rows (empty `transcript_id`, ~60% of rows) load a NULL `na_feature_id`; a non-empty but unresolvable transcript id is fatal.

### Companion change (separate repo)
Requires `ApidbSchema` branch `dnaseq-tables`: adds `VariationFeature.source_id VARCHAR(100) NOT NULL UNIQUE` and drops `VariationTranscriptProduct.downstream_of_frameshift_strain_ids`. That branch needs its own PR/merge.

## Test Plan
- [x] Unit: `Load/t/variationLoader.t` — 34 assertions, no DB (transforms, header parsing, source_id, fatal-vs-NULL semantics, and full-row column-mapping assertions guarding the column-list↔transform lockstep).
- [x] Unit: `Load/t/insertVariationFeatures_unit.t` — 4 assertions, no DB (single-line `\copy` output, schema-identifier guard).
- [x] Integration: `Load/t/insertVariationFeatures_integration.t` — 10 assertions against a live Postgres stub schema; loads the full sample dataset (1504 / 781 / 1978 rows), verifies the intergenic NULL split (797 non-null), and the cascade-delete undo path.
- [x] **Not automated:** the full `ga` plugin run needs a workflow context and an organism present in the target DB (the test DB has no *L. major*). Documented in the design spec for whoever has such an instance.

Design spec and implementation plan are in `docs/superpowers/specs/` and `docs/superpowers/plans/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)