### PR TITLE
Filter taxon name lookup to scientific name in InsertOrthomclClade.pm

### DIFF
--- a/Load/plugin/perl/InsertOrthomclClade.pm
+++ b/Load/plugin/perl/InsertOrthomclClade.pm
@@ -256,9 +256,9 @@ sub parseTaxonToCladeFile {
     my $sql = "SELECT o.orthomcl_abbrev, tn.name
                FROM apidb.organism o
                JOIN sres.taxonname tn ON o.taxon_id = tn.taxon_id
-               WHERE 
-                    o.is_annotated_genome = 1
-                    OR (o.is_annotated_genome = 0 AND o.project_name = 'OrthoMCL')";
+               WHERE tn.name_class = 'scientific name'
+                    AND (o.is_annotated_genome = 1
+                    OR (o.is_annotated_genome = 0 AND o.project_name = 'OrthoMCL'))";
     my $abbrevToNameQuery = $dbh->prepare($sql);
     $abbrevToNameQuery->execute();
 


### PR DESCRIPTION
sres.taxonname holds multiple rows per taxon (scientific name, synonym, type material, etc.) and this query joined without a name_class filter, so the last row fetched silently won in %abbrevToName. NCBI type-material strain designations (e.g. "NCTC 5923", "WDCM00125") were clobbering real organism names for Y. pestis and S. flexneri, corrupting the phyletic search organism tree. Other loaders in this codebase (e.g. InsertOrganism.pm) already filter on name_class = 'scientific name'; this one didn't.